### PR TITLE
refresh frontend: new auth flow, dev mailbox, visual redesign

### DIFF
--- a/src/client/app/api/library.ts
+++ b/src/client/app/api/library.ts
@@ -2,7 +2,8 @@ import { api } from "./client";
 import type { LibraryBook, MediaType } from "./types";
 
 export interface AddBookRequest {
-  catalogBookId?: string;
+  catalogBookId?: string | null;
+  imageId?: string | null;
   title: string;
   description: string;
   mediaType: MediaType;

--- a/src/client/app/api/mail.ts
+++ b/src/client/app/api/mail.ts
@@ -1,0 +1,7 @@
+import { api } from "./client";
+import type { MailMessage } from "./types";
+
+export const mailApi = {
+  getMessages: (email: string) =>
+    api.get<MailMessage[]>(`/mail/${encodeURIComponent(email)}`),
+};

--- a/src/client/app/api/tracking.ts
+++ b/src/client/app/api/tracking.ts
@@ -7,8 +7,8 @@ export interface GetTrackingsResult {
 
 export const trackingApi = {
   getTrackings: () => api.get<GetTrackingsResult>("/tracking/"),
-  startTracking: (libraryBookId: string, totalLength: number) =>
-    api.post<void>("/tracking/", { libraryBookId, totalLength }),
+  startTracking: (libraryBookId: string) =>
+    api.post<void>("/tracking/", { libraryBookId }),
   updateIndex: (trackingId: string, newIndex: number) =>
     api.post<void>(`/tracking/${trackingId}/index`, { newIndex }),
 };

--- a/src/client/app/api/types.ts
+++ b/src/client/app/api/types.ts
@@ -1,6 +1,6 @@
 export interface CatalogBook {
   id: string;
-  imageId?: string;
+  imageId?: string | null;
   title: string;
   description: string;
   textEditionFields: { exist: boolean; totalPages: number };
@@ -12,7 +12,8 @@ export type MediaType = "Ebook" | "Paperback" | "Audiobook";
 export interface LibraryBook {
   id: string;
   userId: string;
-  catalogBookId?: string;
+  catalogBookId?: string | null;
+  imageId?: string | null;
   title: string;
   description: string;
   mediaType: MediaType;
@@ -23,7 +24,6 @@ export interface LibraryBook {
 
 export interface UserProfile {
   name: string;
-  isVerified: boolean;
 }
 
 export interface Tracking {
@@ -34,4 +34,11 @@ export interface Tracking {
   currentIndex: number;
   isStarted: boolean;
   isFinished: boolean;
+}
+
+export interface MailMessage {
+  receiver: string;
+  subject: string;
+  message: string;
+  sentAt: string;
 }

--- a/src/client/app/api/users.ts
+++ b/src/client/app/api/users.ts
@@ -1,8 +1,30 @@
 import { api } from "./client";
 import type { UserProfile } from "./types";
 
+export interface RegisterRequest {
+  name: string;
+  email: string;
+}
+
+export interface VerifyRequest {
+  email: string;
+  verificationCode: string;
+}
+
+export interface LoginRequest {
+  email: string;
+}
+
+export interface ConfirmLoginRequest {
+  loginConfirmationKey: string;
+}
+
 export const usersApi = {
   me: () => api.get<UserProfile>("/users/Me"),
-  login: () => api.post<void>("/users/Login"),
+  register: (body: RegisterRequest) => api.post<void>("/users/Register", body),
+  verify: (body: VerifyRequest) => api.post<void>("/users/Verify", body),
+  login: (body: LoginRequest) => api.post<void>("/users/Login", body),
+  confirmLogin: (body: ConfirmLoginRequest) =>
+    api.post<void>("/users/ConfirmLogin", body),
   logout: () => api.post<void>("/users/Logout"),
 };

--- a/src/client/app/app.css
+++ b/src/client/app/app.css
@@ -3,13 +3,39 @@
 @theme {
   --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-serif: "Fraunces", "Iowan Old Style", "Georgia", serif;
+
+  --color-paper-50: #fbf7f0;
+  --color-paper-100: #f5ecd9;
+  --color-paper-200: #ebdcbb;
+  --color-paper-300: #d9bf8a;
+
+  --color-ink-50: #f5f2ed;
+  --color-ink-700: #3a2e2a;
+  --color-ink-800: #251c1a;
+  --color-ink-900: #181112;
+
+  --color-plum-500: #8b4a8a;
+  --color-plum-600: #6d3a6f;
+  --color-plum-700: #552c59;
+
+  --color-amber-accent: #c98a3b;
 }
 
 html,
 body {
-  @apply bg-white dark:bg-gray-950;
+  background-color: var(--color-paper-50);
+  color: var(--color-ink-800);
 
   @media (prefers-color-scheme: dark) {
+    background-color: var(--color-ink-900);
+    color: var(--color-paper-100);
     color-scheme: dark;
   }
+}
+
+.font-display {
+  font-family: var(--font-serif);
+  font-optical-sizing: auto;
+  letter-spacing: -0.015em;
 }

--- a/src/client/app/components/AddCustomBookModal.tsx
+++ b/src/client/app/components/AddCustomBookModal.tsx
@@ -1,11 +1,18 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { libraryApi } from "../api/library";
 import type { MediaType } from "../api/types";
+import { inputClass, labelClass } from "./AuthShell";
 
 type Props = {
   onClose: () => void;
   onAdded: () => void;
 };
+
+const FORMATS: { value: MediaType; icon: string; label: string }[] = [
+  { value: "Ebook", icon: "📖", label: "Ebook" },
+  { value: "Paperback", icon: "📚", label: "Paperback" },
+  { value: "Audiobook", icon: "🎧", label: "Audiobook" },
+];
 
 export const AddCustomBookModal = ({ onClose, onAdded }: Props) => {
   const [title, setTitle] = useState("");
@@ -14,6 +21,14 @@ export const AddCustomBookModal = ({ onClose, onAdded }: Props) => {
   const [length, setLength] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
 
   const isAudiobook = mediaType === "Audiobook";
   const lengthLabel = isAudiobook ? "Length (minutes)" : "Length (pages)";
@@ -41,17 +56,29 @@ export const AddCustomBookModal = ({ onClose, onAdded }: Props) => {
 
   return (
     <div
-      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+      className="fixed inset-0 bg-ink-900/60 backdrop-blur-sm flex items-center justify-center z-50 p-4"
       onClick={(e) => e.target === e.currentTarget && onClose()}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Add custom book"
     >
-      <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 w-full max-w-md p-6">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
-          Add Custom Book
-        </h2>
+      <div className="bg-white dark:bg-ink-800 rounded-2xl border border-paper-200 dark:border-ink-700 w-full max-w-md p-6 shadow-xl">
+        <div className="flex items-center justify-between mb-5">
+          <h2 className="font-display text-xl font-semibold text-ink-800 dark:text-paper-100">
+            Add a custom book
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="text-ink-700/60 dark:text-paper-200/60 hover:text-ink-800 dark:hover:text-paper-100 cursor-pointer"
+          >
+            ✕
+          </button>
+        </div>
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <div>
-            <label className="block text-sm text-gray-600 dark:text-gray-400 mb-1">
-              Title <span className="text-red-400">*</span>
+            <label className={labelClass}>
+              Title <span className="text-red-500">*</span>
             </label>
             <input
               type="text"
@@ -60,66 +87,68 @@ export const AddCustomBookModal = ({ onClose, onAdded }: Props) => {
               placeholder="Book title"
               required
               autoFocus
-              className="w-full text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className={inputClass}
             />
           </div>
           <div>
-            <label className="block text-sm text-gray-600 dark:text-gray-400 mb-1">
-              Description
-            </label>
+            <label className={labelClass}>Description</label>
             <textarea
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder="Short description (optional)"
               rows={2}
-              className="w-full text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+              className={`${inputClass} resize-none`}
             />
           </div>
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="block text-sm text-gray-600 dark:text-gray-400 mb-1">
-                Format
-              </label>
-              <select
-                value={mediaType}
-                onChange={(e) => setMediaType(e.target.value as MediaType)}
-                className="w-full text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-              >
-                <option value="Ebook">Ebook</option>
-                <option value="Paperback">Paperback</option>
-                <option value="Audiobook">Audiobook</option>
-              </select>
-            </div>
-            <div>
-              <label className="block text-sm text-gray-600 dark:text-gray-400 mb-1">
-                {lengthLabel} <span className="text-red-400">*</span>
-              </label>
-              <input
-                type="number"
-                value={length}
-                onChange={(e) => setLength(e.target.value)}
-                placeholder={lengthPlaceholder}
-                min={1}
-                required
-                className="w-full text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-              />
+          <div>
+            <label className={labelClass}>Format</label>
+            <div className="grid grid-cols-3 gap-2">
+              {FORMATS.map((f) => (
+                <button
+                  key={f.value}
+                  type="button"
+                  onClick={() => setMediaType(f.value)}
+                  className={`text-sm px-3 py-2 rounded-lg border transition-colors cursor-pointer ${
+                    mediaType === f.value
+                      ? "bg-plum-600 text-white border-plum-600"
+                      : "border-paper-200 dark:border-ink-700 text-ink-700 dark:text-paper-200 hover:border-plum-500"
+                  }`}
+                >
+                  <span className="mr-1">{f.icon}</span>
+                  {f.label}
+                </button>
+              ))}
             </div>
           </div>
-          {error && <p className="text-xs text-red-500">{error}</p>}
+          <div>
+            <label className={labelClass}>
+              {lengthLabel} <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="number"
+              value={length}
+              onChange={(e) => setLength(e.target.value)}
+              placeholder={lengthPlaceholder}
+              min={1}
+              required
+              className={inputClass}
+            />
+          </div>
+          {error && <p className="text-sm text-red-600">{error}</p>}
           <div className="flex justify-end gap-2 mt-1">
             <button
               type="button"
               onClick={onClose}
-              className="text-sm px-4 py-2 rounded-lg text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer"
+              className="text-sm px-4 py-2 rounded-lg text-ink-700 dark:text-paper-200 hover:bg-paper-100 dark:hover:bg-ink-900 transition-colors cursor-pointer"
             >
               Cancel
             </button>
             <button
               type="submit"
               disabled={loading || !title.trim() || !length}
-              className="text-sm px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white transition-colors cursor-pointer"
+              className="text-sm px-4 py-2 rounded-lg bg-plum-600 hover:bg-plum-700 disabled:opacity-50 text-white transition-colors cursor-pointer"
             >
-              {loading ? "Adding..." : "Add Book"}
+              {loading ? "Adding..." : "Add book"}
             </button>
           </div>
         </form>

--- a/src/client/app/components/AuthShell.tsx
+++ b/src/client/app/components/AuthShell.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from "react";
+
+type Props = {
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+  footer?: ReactNode;
+};
+
+export const AuthShell = ({ title, subtitle, children, footer }: Props) => (
+  <div className="min-h-screen flex flex-col items-center justify-center bg-paper-50 dark:bg-ink-900 p-6">
+    <div className="w-full max-w-md">
+      <div className="flex items-center gap-2 justify-center mb-8">
+        <span className="inline-block w-9 h-9 rounded-lg bg-gradient-to-br from-plum-600 to-amber-accent" />
+        <span className="font-display text-2xl font-semibold text-ink-800 dark:text-paper-100">
+          Storygame
+        </span>
+      </div>
+      <div className="bg-white dark:bg-ink-800 rounded-2xl border border-paper-200 dark:border-ink-700 p-8 shadow-sm">
+        <h1 className="font-display text-2xl font-semibold text-ink-800 dark:text-paper-100 mb-1">
+          {title}
+        </h1>
+        {subtitle && (
+          <p className="text-sm text-ink-700/70 dark:text-paper-200/70 mb-6">
+            {subtitle}
+          </p>
+        )}
+        {children}
+      </div>
+      {footer && <div className="mt-5 text-center text-sm">{footer}</div>}
+    </div>
+  </div>
+);
+
+export const inputClass =
+  "w-full text-sm rounded-lg border border-paper-200 dark:border-ink-700 bg-paper-50 dark:bg-ink-900 text-ink-800 dark:text-paper-100 px-3.5 py-2.5 placeholder-ink-700/40 dark:placeholder-paper-200/40 focus:outline-none focus:ring-2 focus:ring-plum-500 focus:border-transparent transition-shadow";
+
+export const primaryBtnClass =
+  "w-full bg-plum-600 hover:bg-plum-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-lg px-4 py-2.5 text-sm font-medium transition-colors cursor-pointer";
+
+export const labelClass =
+  "block text-xs font-medium uppercase tracking-wide text-ink-700/80 dark:text-paper-200/70 mb-1.5";

--- a/src/client/app/components/CatalogBookCard.tsx
+++ b/src/client/app/components/CatalogBookCard.tsx
@@ -8,10 +8,12 @@ type Props = {
 };
 
 const lengthForType = (book: CatalogBook, type: MediaType): number =>
-  type === "Audiobook" ? book.audiobookFields.totalMinutes : book.textEditionFields.totalPages;
+  type === "Audiobook"
+    ? book.audiobookFields.totalMinutes
+    : book.textEditionFields.totalPages;
 
 const unitForType = (type: MediaType): string =>
-  type === "Audiobook" ? "minutes" : "pages";
+  type === "Audiobook" ? "min" : "pages";
 
 const availableMediaTypes = (book: CatalogBook): MediaType[] => {
   const types: MediaType[] = [];
@@ -20,11 +22,18 @@ const availableMediaTypes = (book: CatalogBook): MediaType[] => {
   return types;
 };
 
+const FORMAT_ICON: Record<MediaType, string> = {
+  Ebook: "📖",
+  Paperback: "📚",
+  Audiobook: "🎧",
+};
+
 export const CatalogBookCard = ({ book, onAdded }: Props) => {
   const [expanded, setExpanded] = useState(false);
   const [selectedType, setSelectedType] = useState<MediaType | "">("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [added, setAdded] = useState(false);
 
   const handleAdd = async () => {
     if (!selectedType) return;
@@ -33,68 +42,98 @@ export const CatalogBookCard = ({ book, onAdded }: Props) => {
     try {
       await libraryApi.addBook({
         catalogBookId: book.id,
+        imageId: book.imageId ?? null,
         title: book.title,
         description: book.description,
         mediaType: selectedType,
         length: lengthForType(book, selectedType),
       });
-      setExpanded(false);
-      setSelectedType("");
-      onAdded();
+      setAdded(true);
+      setTimeout(() => {
+        setExpanded(false);
+        setSelectedType("");
+        setAdded(false);
+        onAdded();
+      }, 900);
     } catch {
-      setError("Failed to add book. It may already be in your library.");
+      setError("Couldn't add this book. It may already be in your library.");
     } finally {
       setLoading(false);
     }
   };
 
+  const formats = availableMediaTypes(book);
+
   return (
-    <div className="bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-800 p-4">
+    <article className="bg-white dark:bg-ink-800 rounded-xl border border-paper-200 dark:border-ink-700 p-5 hover:border-plum-500/40 dark:hover:border-plum-500/40 transition-colors">
       <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0">
-          <h2 className="font-medium text-gray-900 dark:text-white mb-1">{book.title}</h2>
-          <p className="text-sm text-gray-500 dark:text-gray-400 line-clamp-2">{book.description}</p>
-          <div className="flex gap-3 mt-2 text-xs text-gray-400 dark:text-gray-500">
+        <div className="min-w-0 flex-1">
+          <h2 className="font-display text-lg font-semibold text-ink-800 dark:text-paper-100 mb-1">
+            {book.title}
+          </h2>
+          <p className="text-sm text-ink-700/70 dark:text-paper-200/70 line-clamp-2">
+            {book.description}
+          </p>
+          <div className="flex flex-wrap gap-2 mt-3">
             {book.textEditionFields.exist && (
-              <span>{book.textEditionFields.totalPages} pages</span>
+              <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-paper-100 dark:bg-ink-900 text-ink-700 dark:text-paper-200">
+                <span aria-hidden>📖</span>
+                {book.textEditionFields.totalPages} pages
+              </span>
             )}
             {book.audiobookFields.exist && (
-              <span>{book.audiobookFields.totalMinutes} min audiobook</span>
+              <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-paper-100 dark:bg-ink-900 text-ink-700 dark:text-paper-200">
+                <span aria-hidden>🎧</span>
+                {book.audiobookFields.totalMinutes} min
+              </span>
             )}
           </div>
         </div>
         <button
           onClick={() => setExpanded((v) => !v)}
-          className="shrink-0 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 transition-colors cursor-pointer"
+          className={`shrink-0 text-sm rounded-full px-3.5 py-1.5 border transition-colors cursor-pointer ${
+            expanded
+              ? "border-paper-200 dark:border-ink-700 text-ink-700 dark:text-paper-200 hover:bg-paper-100 dark:hover:bg-ink-900"
+              : "border-plum-600 text-plum-600 dark:text-plum-500 hover:bg-plum-600 hover:text-white"
+          }`}
         >
-          {expanded ? "Cancel" : "Add to Library"}
+          {expanded ? "Cancel" : "Add to library"}
         </button>
       </div>
 
       {expanded && (
-        <div className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-800 flex items-center gap-3">
-          <select
-            value={selectedType}
-            onChange={(e) => setSelectedType(e.target.value as MediaType)}
-            className="text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          >
-            <option value="">Select format...</option>
-            {availableMediaTypes(book).map((t) => (
-              <option key={t} value={t}>
-                {t} — {lengthForType(book, t)} {unitForType(t)}
-              </option>
+        <div className="mt-4 pt-4 border-t border-paper-200 dark:border-ink-700">
+          <p className="text-xs uppercase tracking-wide text-ink-700/60 dark:text-paper-200/60 mb-2">
+            Choose a format
+          </p>
+          <div className="flex flex-wrap gap-2 mb-3">
+            {formats.map((t) => (
+              <button
+                key={t}
+                onClick={() => setSelectedType(t)}
+                className={`text-sm px-3 py-1.5 rounded-lg border transition-colors cursor-pointer ${
+                  selectedType === t
+                    ? "bg-plum-600 text-white border-plum-600"
+                    : "border-paper-200 dark:border-ink-700 text-ink-700 dark:text-paper-200 hover:border-plum-500"
+                }`}
+              >
+                <span className="mr-1.5">{FORMAT_ICON[t]}</span>
+                {t} · {lengthForType(book, t)} {unitForType(t)}
+              </button>
             ))}
-          </select>
-          <button
-            onClick={handleAdd}
-            disabled={!selectedType || loading}
-            className="text-sm bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white rounded-lg px-4 py-1.5 transition-colors cursor-pointer"
-          >
-            {loading ? "Adding..." : "Confirm"}
-          </button>
-          {error && <p className="text-xs text-red-500">{error}</p>}
+          </div>
+          <div className="flex items-center gap-3">
+            <button
+              onClick={handleAdd}
+              disabled={!selectedType || loading || added}
+              className="text-sm bg-plum-600 hover:bg-plum-700 disabled:opacity-50 text-white rounded-lg px-4 py-1.5 transition-colors cursor-pointer"
+            >
+              {added ? "✓ Added" : loading ? "Adding..." : "Add to library"}
+            </button>
+            {error && <p className="text-xs text-red-600">{error}</p>}
+          </div>
         </div>
       )}
-    </div>
+    </article>
   );
 };

--- a/src/client/app/components/CatalogFilters.tsx
+++ b/src/client/app/components/CatalogFilters.tsx
@@ -13,24 +13,40 @@ type Props = {
   onTypeChange: (value: TypeFilter) => void;
 };
 
-export const CatalogFilters = ({ titleFilter, typeFilter, onTitleChange, onTypeChange }: Props) => (
-  <div className="flex gap-3 mb-6">
-    <input
-      type="text"
-      placeholder="Search by title..."
-      value={titleFilter}
-      onChange={(e) => onTitleChange(e.target.value)}
-      className="flex-1 text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-3 py-2 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
-    />
-    <div className="flex rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden text-sm">
+export const CatalogFilters = ({
+  titleFilter,
+  typeFilter,
+  onTitleChange,
+  onTypeChange,
+}: Props) => (
+  <div className="flex flex-col sm:flex-row gap-3 mb-6">
+    <div className="relative flex-1">
+      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-ink-700/40 dark:text-paper-200/40 text-sm">
+        🔍
+      </span>
+      <input
+        type="text"
+        placeholder="Search the catalog by title..."
+        value={titleFilter}
+        onChange={(e) => onTitleChange(e.target.value)}
+        className="w-full text-sm rounded-full border border-paper-200 dark:border-ink-700 bg-white dark:bg-ink-800 text-ink-800 dark:text-paper-100 pl-9 pr-4 py-2.5 placeholder-ink-700/40 dark:placeholder-paper-200/40 focus:outline-none focus:ring-2 focus:ring-plum-500 focus:border-transparent"
+      />
+    </div>
+    <div
+      role="tablist"
+      aria-label="Filter by format"
+      className="flex rounded-full border border-paper-200 dark:border-ink-700 overflow-hidden text-sm bg-white dark:bg-ink-800 p-1 gap-1"
+    >
       {(Object.keys(TYPE_FILTER_LABELS) as TypeFilter[]).map((f) => (
         <button
           key={f}
+          role="tab"
+          aria-selected={typeFilter === f}
           onClick={() => onTypeChange(f)}
-          className={`px-3 py-2 transition-colors cursor-pointer ${
+          className={`px-4 py-1.5 rounded-full transition-colors cursor-pointer ${
             typeFilter === f
-              ? "bg-blue-600 text-white"
-              : "bg-white dark:bg-gray-900 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800"
+              ? "bg-plum-600 text-white"
+              : "text-ink-700 dark:text-paper-200 hover:bg-paper-100 dark:hover:bg-ink-700"
           }`}
         >
           {TYPE_FILTER_LABELS[f]}

--- a/src/client/app/components/LibraryBookCard.tsx
+++ b/src/client/app/components/LibraryBookCard.tsx
@@ -9,12 +9,24 @@ type Props = {
   tracking?: Tracking;
 };
 
-const ProgressBar = ({ current, total }: { current: number; total: number }) => {
-  const pct = total > 0 ? Math.round((current / total) * 100) : 0;
+const ProgressBar = ({
+  current,
+  total,
+}: {
+  current: number;
+  total: number;
+}) => {
+  const pct = total > 0 ? Math.min(100, Math.round((current / total) * 100)) : 0;
   return (
-    <div className="w-full bg-gray-100 dark:bg-gray-800 rounded-full h-1.5 mt-2">
+    <div
+      className="w-full bg-paper-100 dark:bg-ink-900 rounded-full h-2 mt-3 overflow-hidden"
+      role="progressbar"
+      aria-valuenow={pct}
+      aria-valuemin={0}
+      aria-valuemax={100}
+    >
       <div
-        className="bg-blue-500 h-1.5 rounded-full transition-all"
+        className="h-full rounded-full bg-gradient-to-r from-plum-600 to-amber-accent transition-all"
         style={{ width: `${pct}%` }}
       />
     </div>
@@ -39,7 +51,10 @@ const UpdateProgressForm = ({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const parsed = parseInt(value, 10);
-    if (isNaN(parsed) || parsed < 0 || parsed > tracking.totalLength) return;
+    if (isNaN(parsed) || parsed < 0 || parsed > tracking.totalLength) {
+      setError(`Enter a value between 0 and ${tracking.totalLength}.`);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -53,7 +68,7 @@ const UpdateProgressForm = ({
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex items-center gap-2 mt-2">
+    <form onSubmit={handleSubmit} className="flex flex-wrap items-center gap-2 mt-3">
       <input
         type="number"
         value={value}
@@ -61,24 +76,26 @@ const UpdateProgressForm = ({
         min={0}
         max={tracking.totalLength}
         autoFocus
-        className="w-24 text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        className="w-28 text-sm rounded-lg border border-paper-200 dark:border-ink-700 bg-paper-50 dark:bg-ink-900 text-ink-800 dark:text-paper-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-plum-500"
       />
-      <span className="text-xs text-gray-400 dark:text-gray-500">/ {tracking.totalLength} {unit}</span>
+      <span className="text-xs text-ink-700/60 dark:text-paper-200/60">
+        of {tracking.totalLength} {unit}
+      </span>
       <button
         type="submit"
         disabled={loading}
-        className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 disabled:opacity-50 cursor-pointer"
+        className="text-xs bg-plum-600 hover:bg-plum-700 text-white rounded-md px-3 py-1.5 disabled:opacity-50 cursor-pointer"
       >
         {loading ? "Saving..." : "Save"}
       </button>
       <button
         type="button"
         onClick={onCancel}
-        className="text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 cursor-pointer"
+        className="text-xs text-ink-700/70 dark:text-paper-200/70 hover:text-ink-800 dark:hover:text-paper-100 cursor-pointer"
       >
         Cancel
       </button>
-      {error && <span className="text-xs text-red-500">{error}</span>}
+      {error && <span className="text-xs text-red-600 basis-full">{error}</span>}
     </form>
   );
 };
@@ -95,7 +112,7 @@ export const LibraryBookCard = ({ book, tracking }: Props) => {
     setLoading(true);
     setError(null);
     try {
-      await trackingApi.startTracking(book.id, book.length);
+      await trackingApi.startTracking(book.id);
       revalidator.revalidate();
     } catch {
       setError("Failed to start tracking.");
@@ -104,42 +121,56 @@ export const LibraryBookCard = ({ book, tracking }: Props) => {
     }
   };
 
-  const addedDate = new Date(book.addedToLibraryAt).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
+  const addedDate = new Date(book.addedToLibraryAt).toLocaleDateString(
+    undefined,
+    { month: "short", day: "numeric", year: "numeric" }
+  );
+
+  const pct = tracking
+    ? Math.round((tracking.currentIndex / Math.max(1, tracking.totalLength)) * 100)
+    : 0;
 
   return (
-    <div className="bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-800 p-4">
+    <article className="bg-white dark:bg-ink-800 rounded-xl border border-paper-200 dark:border-ink-700 p-5">
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2 mb-1">
-            <h2 className="font-medium text-gray-900 dark:text-white truncate">{book.title}</h2>
+          <div className="flex flex-wrap items-center gap-2 mb-1">
+            <h2 className="font-display text-lg font-semibold text-ink-800 dark:text-paper-100 truncate">
+              {book.title}
+            </h2>
             <MediaTypeBadge type={book.mediaType} />
+            {tracking?.isFinished && (
+              <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 ring-1 ring-inset ring-emerald-500/20 font-medium">
+                ✓ Finished
+              </span>
+            )}
           </div>
-          <p className="text-sm text-gray-500 dark:text-gray-400 line-clamp-2">{book.description}</p>
-          <div className="flex items-center gap-3 mt-1.5">
-            <span className="text-xs text-gray-400 dark:text-gray-500">
+          <p className="text-sm text-ink-700/70 dark:text-paper-200/70 line-clamp-2">
+            {book.description}
+          </p>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-2 text-xs text-ink-700/60 dark:text-paper-200/60">
+            <span>
               {book.length} {unit}
             </span>
-            {!tracking && (
-              <span className="text-xs text-gray-400 dark:text-gray-500">Added {addedDate}</span>
-            )}
-            {tracking && tracking.isFinished && (
-              <span className="text-xs font-medium text-green-600 dark:text-green-400">✓ Finished</span>
-            )}
-            {tracking && !tracking.isFinished && !editingProgress && (
-              <button
-                onClick={() => setEditingProgress(true)}
-                className="text-xs text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 transition-colors cursor-pointer"
-              >
-                {tracking.currentIndex} / {tracking.totalLength} {unit} — update
-              </button>
-            )}
+            <span aria-hidden>·</span>
+            <span>Added {addedDate}</span>
           </div>
-          {error && <p className="text-xs text-red-500 mt-1">{error}</p>}
-          {tracking && !tracking.isFinished && editingProgress && (
+          {error && <p className="text-xs text-red-600 mt-1">{error}</p>}
+        </div>
+        {!tracking && (
+          <button
+            onClick={handleStartTracking}
+            disabled={loading}
+            className="shrink-0 text-sm rounded-full px-3.5 py-1.5 border border-plum-600 text-plum-600 dark:text-plum-500 hover:bg-plum-600 hover:text-white disabled:opacity-50 transition-colors cursor-pointer"
+          >
+            {loading ? "Starting..." : "Start tracking"}
+          </button>
+        )}
+      </div>
+
+      {tracking && !tracking.isFinished && (
+        <div className="mt-2">
+          {editingProgress ? (
             <UpdateProgressForm
               tracking={tracking}
               unit={unit}
@@ -149,21 +180,35 @@ export const LibraryBookCard = ({ book, tracking }: Props) => {
               }}
               onCancel={() => setEditingProgress(false)}
             />
-          )}
-          {tracking && !tracking.isFinished && !editingProgress && (
-            <ProgressBar current={tracking.currentIndex} total={tracking.totalLength} />
+          ) : (
+            <button
+              type="button"
+              onClick={() => setEditingProgress(true)}
+              className="group w-full text-left cursor-pointer"
+            >
+              <div className="flex items-center justify-between text-xs text-ink-700/70 dark:text-paper-200/70">
+                <span>
+                  <span className="font-medium text-ink-800 dark:text-paper-100">
+                    {tracking.currentIndex}
+                  </span>{" "}
+                  / {tracking.totalLength} {unit} · {pct}%
+                </span>
+                <span className="text-plum-600 dark:text-plum-500 opacity-0 group-hover:opacity-100 transition-opacity">
+                  Update progress →
+                </span>
+              </div>
+              <ProgressBar
+                current={tracking.currentIndex}
+                total={tracking.totalLength}
+              />
+            </button>
           )}
         </div>
-        {!tracking && (
-          <button
-            onClick={handleStartTracking}
-            disabled={loading}
-            className="shrink-0 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 disabled:opacity-50 transition-colors cursor-pointer"
-          >
-            {loading ? "Starting..." : "Start tracking"}
-          </button>
-        )}
-      </div>
-    </div>
+      )}
+
+      {tracking?.isFinished && (
+        <ProgressBar current={tracking.totalLength} total={tracking.totalLength} />
+      )}
+    </article>
   );
 };

--- a/src/client/app/components/MediaTypeBadge.tsx
+++ b/src/client/app/components/MediaTypeBadge.tsx
@@ -4,14 +4,26 @@ type Props = {
   type: MediaType;
 };
 
-const BADGE_COLORS: Record<MediaType, string> = {
-  Ebook: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
-  Paperback: "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300",
-  Audiobook: "bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300",
+const BADGE_STYLES: Record<MediaType, string> = {
+  Ebook:
+    "bg-plum-500/10 text-plum-700 dark:bg-plum-500/20 dark:text-plum-500 ring-plum-500/20",
+  Paperback:
+    "bg-amber-accent/10 text-amber-accent dark:bg-amber-accent/20 ring-amber-accent/20",
+  Audiobook:
+    "bg-emerald-500/10 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400 ring-emerald-500/20",
+};
+
+const ICONS: Record<MediaType, string> = {
+  Ebook: "📖",
+  Paperback: "📚",
+  Audiobook: "🎧",
 };
 
 export const MediaTypeBadge = ({ type }: Props) => (
-  <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${BADGE_COLORS[type]}`}>
+  <span
+    className={`inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-medium ring-1 ring-inset ${BADGE_STYLES[type]}`}
+  >
+    <span aria-hidden>{ICONS[type]}</span>
     {type}
   </span>
 );

--- a/src/client/app/components/Navbar.tsx
+++ b/src/client/app/components/Navbar.tsx
@@ -1,40 +1,63 @@
 import { NavLink, useNavigate } from "react-router";
 import { usersApi } from "../api/users";
 
+type NavbarProps = {
+  userName?: string;
+};
+
 const navLinkClass = ({ isActive }: { isActive: boolean }) =>
-  `text-sm ${isActive ? "text-blue-600 dark:text-blue-400 font-medium" : "text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"}`;
+  `px-3 py-1.5 rounded-full text-sm transition-colors ${
+    isActive
+      ? "bg-plum-600 text-white"
+      : "text-ink-700 dark:text-paper-200 hover:bg-paper-100 dark:hover:bg-ink-800"
+  }`;
 
 const LogoutButton = () => {
   const navigate = useNavigate();
-
   const handleLogout = async () => {
-    await usersApi.logout();
-    navigate("/login");
+    try {
+      await usersApi.logout();
+    } finally {
+      navigate("/login");
+    }
   };
-
   return (
     <button
       onClick={handleLogout}
-      className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors cursor-pointer"
+      className="text-sm text-ink-700 dark:text-paper-200 hover:text-plum-600 dark:hover:text-plum-500 transition-colors cursor-pointer"
     >
       Sign out
     </button>
   );
 };
 
-export const Navbar = () => (
-  <nav className="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800">
-    <div className="max-w-4xl mx-auto px-4 h-14 flex items-center justify-between">
-      <div className="flex items-center gap-6">
-        <span className="font-semibold text-gray-900 dark:text-white">Storygame</span>
-        <NavLink to="/" end className={navLinkClass}>
-          Library
+export const Navbar = ({ userName }: NavbarProps) => (
+  <nav className="bg-paper-50/80 dark:bg-ink-900/80 backdrop-blur border-b border-paper-200 dark:border-ink-800 sticky top-0 z-10">
+    <div className="max-w-5xl mx-auto px-4 h-16 flex items-center justify-between gap-4">
+      <div className="flex items-center gap-5 min-w-0">
+        <NavLink to="/" className="flex items-center gap-2 shrink-0">
+          <span className="inline-block w-8 h-8 rounded-lg bg-gradient-to-br from-plum-600 to-amber-accent" />
+          <span className="font-display text-xl font-semibold text-ink-800 dark:text-paper-100">
+            Storygame
+          </span>
         </NavLink>
-        <NavLink to="/catalog" className={navLinkClass}>
-          Catalog
-        </NavLink>
+        <div className="flex items-center gap-1 ml-2">
+          <NavLink to="/" end className={navLinkClass}>
+            Library
+          </NavLink>
+          <NavLink to="/catalog" className={navLinkClass}>
+            Catalog
+          </NavLink>
+        </div>
       </div>
-      <LogoutButton />
+      <div className="flex items-center gap-4">
+        {userName && (
+          <span className="hidden sm:inline text-sm text-ink-700 dark:text-paper-200">
+            Hello, <span className="font-medium">{userName}</span>
+          </span>
+        )}
+        <LogoutButton />
+      </div>
     </div>
   </nav>
 );

--- a/src/client/app/root.tsx
+++ b/src/client/app/root.tsx
@@ -19,7 +19,7 @@ export const links: Route.LinksFunction = () => [
   },
   {
     rel: "stylesheet",
-    href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
+    href: "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&display=swap",
   },
 ];
 
@@ -32,7 +32,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Meta />
         <Links />
       </head>
-      <body>
+      <body className="antialiased">
         {children}
         <ScrollRestoration />
         <Scripts />
@@ -46,15 +46,15 @@ export default function App() {
 }
 
 export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  let message = "Oops!";
+  let message = "Something went sideways";
   let details = "An unexpected error occurred.";
   let stack: string | undefined;
 
   if (isRouteErrorResponse(error)) {
-    message = error.status === 404 ? "404" : "Error";
+    message = error.status === 404 ? "Page not found" : "Error";
     details =
       error.status === 404
-        ? "The requested page could not be found."
+        ? "The page you're looking for isn't here."
         : error.statusText || details;
   } else if (import.meta.env.DEV && error && error instanceof Error) {
     details = error.message;
@@ -62,14 +62,18 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
   }
 
   return (
-    <main className="pt-16 p-4 container mx-auto">
-      <h1>{message}</h1>
-      <p>{details}</p>
-      {stack && (
-        <pre className="w-full p-4 overflow-x-auto">
-          <code>{stack}</code>
-        </pre>
-      )}
+    <main className="min-h-screen flex items-center justify-center p-6">
+      <div className="max-w-lg w-full bg-white dark:bg-ink-800 rounded-2xl border border-paper-200 dark:border-ink-700 p-8 shadow-sm">
+        <h1 className="font-display text-3xl font-semibold text-ink-800 dark:text-paper-100 mb-2">
+          {message}
+        </h1>
+        <p className="text-ink-700 dark:text-paper-200">{details}</p>
+        {stack && (
+          <pre className="w-full mt-4 p-4 overflow-x-auto text-xs bg-paper-100 dark:bg-ink-900 rounded-lg">
+            <code>{stack}</code>
+          </pre>
+        )}
+      </div>
     </main>
   );
 }

--- a/src/client/app/routes.ts
+++ b/src/client/app/routes.ts
@@ -2,6 +2,8 @@ import { type RouteConfig, index, layout, route } from "@react-router/dev/routes
 
 export default [
   route("login", "routes/login.tsx"),
+  route("register", "routes/register.tsx"),
+  route("mail", "routes/mail.tsx"),
   layout("routes/_layout.tsx", [
     index("routes/library.tsx"),
     route("catalog", "routes/catalog.tsx"),

--- a/src/client/app/routes/_layout.tsx
+++ b/src/client/app/routes/_layout.tsx
@@ -1,27 +1,33 @@
-import { Outlet, redirect } from "react-router";
+import { Outlet, redirect, useLoaderData } from "react-router";
 import { ApiError } from "../api/client";
 import { usersApi } from "../api/users";
+import type { UserProfile } from "../api/types";
 import { Navbar } from "../components/Navbar";
 
 export async function clientLoader() {
   try {
-    await usersApi.me();
+    const me = await usersApi.me();
+    return { me };
   } catch (e) {
     if (e instanceof ApiError && e.status === 401) {
       return redirect("/login");
     }
     throw e;
   }
-  return null;
 }
 
-const Layout = () => (
-  <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
-    <Navbar />
-    <main className="max-w-4xl mx-auto px-4 py-8">
-      <Outlet />
-    </main>
-  </div>
-);
+type LoaderData = { me: UserProfile };
+
+const Layout = () => {
+  const { me } = useLoaderData() as LoaderData;
+  return (
+    <div className="min-h-screen bg-paper-50 dark:bg-ink-900">
+      <Navbar userName={me.name} />
+      <main className="max-w-5xl mx-auto px-4 py-10">
+        <Outlet />
+      </main>
+    </div>
+  );
+};
 
 export default Layout;

--- a/src/client/app/routes/catalog.tsx
+++ b/src/client/app/routes/catalog.tsx
@@ -1,5 +1,5 @@
 import { useRevalidator } from "react-router";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { catalogApi } from "../api/catalog";
 import type { CatalogBook } from "../api/types";
 import { CatalogBookCard } from "../components/CatalogBookCard";
@@ -12,29 +12,55 @@ export async function clientLoader() {
 
 export const meta = () => [{ title: "Catalog — Storygame" }];
 
-const matchesTypeFilter = (book: CatalogBook, filter: TypeFilter): boolean => {
-  if (filter === "all") return true;
-  if (filter === "text") return book.textEditionFields.exist;
-  return book.audiobookFields.exist;
-};
-
 type LoaderData = { books: CatalogBook[] };
 
+const typeFilterToParams = (filter: TypeFilter) => {
+  if (filter === "text") return { hasTextEdition: true };
+  if (filter === "audio") return { hasAudiobook: true };
+  return {};
+};
+
 const Catalog = ({ loaderData }: { loaderData: LoaderData }) => {
-  const { books } = loaderData;
+  const [books, setBooks] = useState(loaderData.books);
   const revalidator = useRevalidator();
   const [titleFilter, setTitleFilter] = useState("");
   const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
+  const [searching, setSearching] = useState(false);
+  const debounceRef = useRef<number | null>(null);
 
-  const filtered = books.filter(
-    (b) =>
-      b.title.toLowerCase().includes(titleFilter.toLowerCase()) &&
-      matchesTypeFilter(b, typeFilter),
-  );
+  useEffect(() => {
+    setBooks(loaderData.books);
+  }, [loaderData.books]);
+
+  useEffect(() => {
+    if (debounceRef.current) window.clearTimeout(debounceRef.current);
+    debounceRef.current = window.setTimeout(async () => {
+      setSearching(true);
+      try {
+        const data = await catalogApi.search({
+          titleContains: titleFilter.trim() || undefined,
+          ...typeFilterToParams(typeFilter),
+        });
+        setBooks(data.books);
+      } finally {
+        setSearching(false);
+      }
+    }, 250);
+    return () => {
+      if (debounceRef.current) window.clearTimeout(debounceRef.current);
+    };
+  }, [titleFilter, typeFilter]);
 
   return (
     <div>
-      <h1 className="text-xl font-semibold text-gray-900 dark:text-white mb-6">Catalog</h1>
+      <header className="mb-8">
+        <h1 className="font-display text-3xl font-semibold text-ink-800 dark:text-paper-100">
+          Catalog
+        </h1>
+        <p className="text-sm text-ink-700/70 dark:text-paper-200/70 mt-1">
+          Browse curated titles and add them to your library.
+        </p>
+      </header>
 
       <CatalogFilters
         titleFilter={titleFilter}
@@ -43,11 +69,20 @@ const Catalog = ({ loaderData }: { loaderData: LoaderData }) => {
         onTypeChange={setTypeFilter}
       />
 
-      {filtered.length === 0 ? (
-        <p className="text-center py-12 text-gray-500 dark:text-gray-400">No books found.</p>
+      {searching && (
+        <p className="text-xs text-ink-700/50 dark:text-paper-200/50 mb-3">
+          Searching...
+        </p>
+      )}
+
+      {books.length === 0 ? (
+        <div className="text-center py-16 text-ink-700/60 dark:text-paper-200/60">
+          <p className="font-display text-xl mb-1">No matches found</p>
+          <p className="text-sm">Try a different title or format.</p>
+        </div>
       ) : (
         <div className="grid gap-3">
-          {filtered.map((book) => (
+          {books.map((book) => (
             <CatalogBookCard
               key={book.id}
               book={book}

--- a/src/client/app/routes/library.tsx
+++ b/src/client/app/routes/library.tsx
@@ -1,5 +1,5 @@
 import { Link, useRevalidator } from "react-router";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { libraryApi } from "../api/library";
 import { trackingApi } from "../api/tracking";
 import type { LibraryBook, Tracking } from "../api/types";
@@ -12,37 +12,80 @@ export async function clientLoader() {
     trackingApi.getTrackings(),
   ]);
   const trackingsMap: Record<string, Tracking> = Object.fromEntries(
-    (trackingData.trackings ?? []).map((t) => [t.libraryBookId, t]),
+    (trackingData.trackings ?? []).map((t) => [t.libraryBookId, t])
   );
   return { books: libraryData.books ?? [], trackingsMap };
 }
 
 export const meta = () => [{ title: "Library — Storygame" }];
 
+type LoaderData = {
+  books: LibraryBook[];
+  trackingsMap: Record<string, Tracking>;
+};
+
+type ViewFilter = "all" | "reading" | "finished" | "not-started";
+
+const VIEW_LABELS: Record<ViewFilter, string> = {
+  all: "All",
+  reading: "Reading",
+  finished: "Finished",
+  "not-started": "Not started",
+};
+
 const EmptyLibrary = ({ onAddCustom }: { onAddCustom: () => void }) => (
-  <div className="text-center py-16 text-gray-500 dark:text-gray-400">
-    <p className="mb-2">Your library is empty.</p>
-    <div className="flex items-center justify-center gap-3 mt-3">
-      <Link to="/catalog" className="text-sm text-blue-600 dark:text-blue-400 hover:underline">
-        Browse the catalog
+  <div className="text-center py-16 bg-white dark:bg-ink-800 rounded-2xl border border-dashed border-paper-200 dark:border-ink-700">
+    <p className="font-display text-2xl text-ink-800 dark:text-paper-100 mb-1">
+      Your library is waiting
+    </p>
+    <p className="text-sm text-ink-700/70 dark:text-paper-200/70 mb-5">
+      Add the books and audiobooks you're reading to start tracking progress.
+    </p>
+    <div className="flex items-center justify-center gap-2">
+      <Link
+        to="/catalog"
+        className="text-sm bg-plum-600 hover:bg-plum-700 text-white rounded-lg px-4 py-2 transition-colors"
+      >
+        Browse catalog
       </Link>
-      <span className="text-gray-300 dark:text-gray-600">or</span>
       <button
         onClick={onAddCustom}
-        className="text-sm text-blue-600 dark:text-blue-400 hover:underline cursor-pointer"
+        className="text-sm border border-paper-200 dark:border-ink-700 hover:bg-paper-100 dark:hover:bg-ink-900 text-ink-700 dark:text-paper-200 rounded-lg px-4 py-2 transition-colors cursor-pointer"
       >
-        add a custom book
+        Add custom book
       </button>
     </div>
   </div>
 );
 
-type LoaderData = { books: LibraryBook[]; trackingsMap: Record<string, Tracking> };
-
 const Library = ({ loaderData }: { loaderData: LoaderData }) => {
   const { books, trackingsMap } = loaderData;
   const revalidator = useRevalidator();
   const [showAddModal, setShowAddModal] = useState(false);
+  const [view, setView] = useState<ViewFilter>("all");
+
+  const stats = useMemo(() => {
+    let reading = 0;
+    let finished = 0;
+    let notStarted = 0;
+    for (const b of books) {
+      const t = trackingsMap[b.id];
+      if (!t) notStarted++;
+      else if (t.isFinished) finished++;
+      else reading++;
+    }
+    return { total: books.length, reading, finished, notStarted };
+  }, [books, trackingsMap]);
+
+  const visibleBooks = useMemo(() => {
+    if (view === "all") return books;
+    return books.filter((b) => {
+      const t = trackingsMap[b.id];
+      if (view === "not-started") return !t;
+      if (view === "reading") return t && !t.isFinished;
+      return t?.isFinished;
+    });
+  }, [books, trackingsMap, view]);
 
   const handleBookAdded = () => {
     setShowAddModal(false);
@@ -51,36 +94,84 @@ const Library = ({ loaderData }: { loaderData: LoaderData }) => {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-xl font-semibold text-gray-900 dark:text-white">My Library</h1>
+      <header className="mb-8 flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
+        <div>
+          <h1 className="font-display text-3xl font-semibold text-ink-800 dark:text-paper-100">
+            My library
+          </h1>
+          <p className="text-sm text-ink-700/70 dark:text-paper-200/70 mt-1">
+            {stats.total === 0
+              ? "Nothing here yet."
+              : `${stats.total} title${stats.total === 1 ? "" : "s"} · ${stats.reading} in progress · ${stats.finished} finished`}
+          </p>
+        </div>
         <div className="flex gap-2">
           <button
             onClick={() => setShowAddModal(true)}
-            className="text-sm border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300 rounded-lg px-4 py-2 transition-colors cursor-pointer"
+            className="text-sm border border-paper-200 dark:border-ink-700 hover:bg-paper-100 dark:hover:bg-ink-800 text-ink-700 dark:text-paper-200 rounded-lg px-4 py-2 transition-colors cursor-pointer"
           >
-            Add Custom Book
+            + Custom book
           </button>
           <Link
             to="/catalog"
-            className="text-sm bg-blue-600 hover:bg-blue-700 text-white rounded-lg px-4 py-2 transition-colors"
+            className="text-sm bg-plum-600 hover:bg-plum-700 text-white rounded-lg px-4 py-2 transition-colors"
           >
-            Browse Catalog
+            Browse catalog
           </Link>
         </div>
-      </div>
+      </header>
 
       {books.length === 0 ? (
         <EmptyLibrary onAddCustom={() => setShowAddModal(true)} />
       ) : (
-        <div className="grid gap-3">
-          {books.map((book) => (
-            <LibraryBookCard
-              key={book.id}
-              book={book}
-              tracking={trackingsMap[book.id]}
-            />
-          ))}
-        </div>
+        <>
+          <div className="flex flex-wrap gap-1 p-1 rounded-full bg-white dark:bg-ink-800 border border-paper-200 dark:border-ink-700 w-fit mb-5">
+            {(Object.keys(VIEW_LABELS) as ViewFilter[]).map((v) => {
+              const count =
+                v === "all"
+                  ? stats.total
+                  : v === "reading"
+                    ? stats.reading
+                    : v === "finished"
+                      ? stats.finished
+                      : stats.notStarted;
+              return (
+                <button
+                  key={v}
+                  onClick={() => setView(v)}
+                  className={`text-sm px-3.5 py-1.5 rounded-full transition-colors cursor-pointer ${
+                    view === v
+                      ? "bg-plum-600 text-white"
+                      : "text-ink-700 dark:text-paper-200 hover:bg-paper-100 dark:hover:bg-ink-900"
+                  }`}
+                >
+                  {VIEW_LABELS[v]}
+                  <span
+                    className={`ml-1.5 text-xs ${view === v ? "text-white/80" : "text-ink-700/50 dark:text-paper-200/50"}`}
+                  >
+                    {count}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+
+          {visibleBooks.length === 0 ? (
+            <p className="text-center py-12 text-ink-700/60 dark:text-paper-200/60 text-sm">
+              Nothing in this section.
+            </p>
+          ) : (
+            <div className="grid gap-3">
+              {visibleBooks.map((book) => (
+                <LibraryBookCard
+                  key={book.id}
+                  book={book}
+                  tracking={trackingsMap[book.id]}
+                />
+              ))}
+            </div>
+          )}
+        </>
       )}
 
       {showAddModal && (

--- a/src/client/app/routes/mail.tsx
+++ b/src/client/app/routes/mail.tsx
@@ -1,0 +1,161 @@
+import { Link } from "react-router";
+import { useState } from "react";
+import { mailApi } from "../api/mail";
+import { ApiError } from "../api/client";
+import type { MailMessage } from "../api/types";
+import { inputClass, labelClass } from "../components/AuthShell";
+
+export function meta() {
+  return [{ title: "Dev mailbox — Storygame" }];
+}
+
+const formatDate = (iso: string) => {
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};
+
+const MessageItem = ({ msg }: { msg: MailMessage }) => {
+  const [copied, setCopied] = useState(false);
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(msg.message);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // ignore
+    }
+  };
+  return (
+    <li className="bg-white dark:bg-ink-800 rounded-xl border border-paper-200 dark:border-ink-700 p-5">
+      <div className="flex items-start justify-between gap-3 mb-2">
+        <div>
+          <p className="font-display text-lg font-semibold text-ink-800 dark:text-paper-100">
+            {msg.subject}
+          </p>
+          <p className="text-xs text-ink-700/60 dark:text-paper-200/60 mt-0.5">
+            To {msg.receiver} · {formatDate(msg.sentAt)}
+          </p>
+        </div>
+        <button
+          onClick={copy}
+          className="shrink-0 text-xs font-medium px-2.5 py-1 rounded-md border border-paper-200 dark:border-ink-700 text-ink-700 dark:text-paper-200 hover:bg-paper-100 dark:hover:bg-ink-700 transition-colors cursor-pointer"
+        >
+          {copied ? "Copied!" : "Copy code"}
+        </button>
+      </div>
+      <pre className="font-mono text-sm bg-paper-100 dark:bg-ink-900 text-ink-800 dark:text-paper-100 rounded-lg p-3 whitespace-pre-wrap break-all">
+        {msg.message}
+      </pre>
+    </li>
+  );
+};
+
+export default function Mail() {
+  const [email, setEmail] = useState("");
+  const [messages, setMessages] = useState<MailMessage[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async (e?: React.FormEvent) => {
+    e?.preventDefault();
+    if (!email.trim()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await mailApi.getMessages(email.trim());
+      const sorted = [...data].sort(
+        (a, b) => new Date(b.sentAt).getTime() - new Date(a.sentAt).getTime()
+      );
+      setMessages(sorted);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 404) {
+        setError(
+          "Dev mailbox is only available when the backend runs in Development mode."
+        );
+      } else {
+        setError("Couldn't load messages. Try again.");
+      }
+      setMessages(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-paper-50 dark:bg-ink-900 p-6">
+      <div className="max-w-2xl mx-auto">
+        <div className="flex items-center justify-between mb-8">
+          <div className="flex items-center gap-2">
+            <span className="inline-block w-9 h-9 rounded-lg bg-gradient-to-br from-plum-600 to-amber-accent" />
+            <div>
+              <h1 className="font-display text-2xl font-semibold text-ink-800 dark:text-paper-100">
+                Dev mailbox
+              </h1>
+              <p className="text-xs text-ink-700/60 dark:text-paper-200/60">
+                Read simulated emails for any address (development only).
+              </p>
+            </div>
+          </div>
+          <Link
+            to="/login"
+            className="text-sm text-plum-600 dark:text-plum-500 hover:underline"
+          >
+            ← Back to sign in
+          </Link>
+        </div>
+
+        <form
+          onSubmit={load}
+          className="bg-white dark:bg-ink-800 rounded-2xl border border-paper-200 dark:border-ink-700 p-5 mb-6 flex gap-3 items-end"
+        >
+          <div className="flex-1">
+            <label className={labelClass}>Email address</label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              required
+              className={inputClass}
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={loading}
+            className="shrink-0 bg-plum-600 hover:bg-plum-700 disabled:opacity-50 text-white rounded-lg px-5 py-2.5 text-sm font-medium transition-colors cursor-pointer"
+          >
+            {loading ? "Loading..." : "Fetch mail"}
+          </button>
+        </form>
+
+        {error && (
+          <div className="bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 text-red-700 dark:text-red-300 rounded-lg p-4 mb-4 text-sm">
+            {error}
+          </div>
+        )}
+
+        {messages !== null && (
+          <>
+            {messages.length === 0 ? (
+              <div className="text-center py-12 text-ink-700/60 dark:text-paper-200/60">
+                No messages for <span className="font-medium">{email}</span>{" "}
+                yet.
+              </div>
+            ) : (
+              <ul className="flex flex-col gap-3">
+                {messages.map((m, i) => (
+                  <MessageItem key={`${m.sentAt}-${i}`} msg={m} />
+                ))}
+              </ul>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/client/app/routes/not-found.tsx
+++ b/src/client/app/routes/not-found.tsx
@@ -1,8 +1,25 @@
+import { Link } from "react-router";
+
 export default function NotFound() {
   return (
-    <div>
-      <h1>404 - Page Not Found</h1>
-      <p>The page you're looking for doesn't exist.</p>
+    <div className="min-h-screen flex items-center justify-center bg-paper-50 dark:bg-ink-900 p-6">
+      <div className="text-center max-w-sm">
+        <p className="font-display text-7xl font-semibold bg-gradient-to-br from-plum-600 to-amber-accent bg-clip-text text-transparent">
+          404
+        </p>
+        <h1 className="font-display text-2xl font-semibold text-ink-800 dark:text-paper-100 mt-4 mb-2">
+          This chapter isn't written yet
+        </h1>
+        <p className="text-sm text-ink-700/70 dark:text-paper-200/70 mb-6">
+          The page you're looking for doesn't exist.
+        </p>
+        <Link
+          to="/"
+          className="inline-block text-sm bg-plum-600 hover:bg-plum-700 text-white rounded-lg px-4 py-2 transition-colors"
+        >
+          Back to your library
+        </Link>
+      </div>
     </div>
   );
 }

--- a/src/client/app/routes/register.tsx
+++ b/src/client/app/routes/register.tsx
@@ -20,33 +20,34 @@ export async function clientLoader() {
 }
 
 export function meta() {
-  return [{ title: "Sign in — Storygame" }];
+  return [{ title: "Create account — Storygame" }];
 }
 
-type Step = "email" | "confirm";
+type Step = "form" | "verify";
 
-export default function Login() {
+export default function Register() {
   const navigate = useNavigate();
-  const [step, setStep] = useState<Step>("email");
+  const [step, setStep] = useState<Step>("form");
+  const [name, setName] = useState("");
   const [email, setEmail] = useState("");
-  const [confirmKey, setConfirmKey] = useState("");
+  const [code, setCode] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleRequestLogin = async (e: React.FormEvent) => {
+  const handleRegister = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!email.trim()) return;
+    if (!name.trim() || !email.trim()) return;
     setLoading(true);
     setError(null);
     try {
-      await usersApi.login({ email: email.trim() });
-      setStep("confirm");
+      await usersApi.register({ name: name.trim(), email: email.trim() });
+      setStep("verify");
     } catch (err) {
       if (err instanceof ApiError && err.status === 429) {
-        setError("Too many attempts. Please wait a minute and try again.");
+        setError("Too many attempts. Please wait a minute.");
       } else {
         setError(
-          "We couldn't send the sign-in email. Check that this address is registered and verified."
+          "Couldn't create your account. That email may already be registered."
         );
       }
     } finally {
@@ -54,25 +55,28 @@ export default function Login() {
     }
   };
 
-  const handleConfirm = async (e: React.FormEvent) => {
+  const handleVerify = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!confirmKey.trim()) return;
+    if (!code.trim()) return;
     setLoading(true);
     setError(null);
     try {
-      await usersApi.confirmLogin({ loginConfirmationKey: confirmKey.trim() });
-      navigate("/");
+      await usersApi.verify({
+        email: email.trim(),
+        verificationCode: code.trim(),
+      });
+      navigate("/login");
     } catch {
-      setError("Invalid or expired code. Try requesting a new sign-in email.");
+      setError("Invalid or expired code.");
       setLoading(false);
     }
   };
 
-  if (step === "confirm") {
+  if (step === "verify") {
     return (
       <AuthShell
-        title="Check your inbox"
-        subtitle={`We sent a one-time sign-in code to ${email}. Paste it below to continue.`}
+        title="Verify your email"
+        subtitle={`We sent a verification code to ${email}. Paste it below to activate your account.`}
         footer={
           <Link
             to="/mail"
@@ -82,13 +86,13 @@ export default function Login() {
           </Link>
         }
       >
-        <form onSubmit={handleConfirm} className="flex flex-col gap-4">
+        <form onSubmit={handleVerify} className="flex flex-col gap-4">
           <div>
-            <label className={labelClass}>Sign-in code</label>
+            <label className={labelClass}>Verification code</label>
             <input
               type="text"
-              value={confirmKey}
-              onChange={(e) => setConfirmKey(e.target.value)}
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
               placeholder="Paste the code from the email"
               required
               autoFocus
@@ -99,19 +103,11 @@ export default function Login() {
             <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
           )}
           <button type="submit" disabled={loading} className={primaryBtnClass}>
-            {loading ? "Signing you in..." : "Sign in"}
+            {loading ? "Verifying..." : "Verify & continue"}
           </button>
-          <button
-            type="button"
-            onClick={() => {
-              setStep("email");
-              setConfirmKey("");
-              setError(null);
-            }}
-            className="text-xs text-ink-700/70 dark:text-paper-200/70 hover:text-plum-600 dark:hover:text-plum-500 transition-colors cursor-pointer"
-          >
-            ← Use a different email
-          </button>
+          <p className="text-xs text-ink-700/60 dark:text-paper-200/60 text-center">
+            After verifying, you'll sign in from the login page.
+          </p>
         </form>
       </AuthShell>
     );
@@ -119,21 +115,33 @@ export default function Login() {
 
   return (
     <AuthShell
-      title="Welcome back"
-      subtitle="We'll email you a one-time code to sign in."
+      title="Create your account"
+      subtitle="Start tracking what you read and listen to."
       footer={
         <span className="text-ink-700/70 dark:text-paper-200/70">
-          New here?{" "}
+          Already have an account?{" "}
           <Link
-            to="/register"
+            to="/login"
             className="text-plum-600 dark:text-plum-500 hover:underline font-medium"
           >
-            Create an account
+            Sign in
           </Link>
         </span>
       }
     >
-      <form onSubmit={handleRequestLogin} className="flex flex-col gap-4">
+      <form onSubmit={handleRegister} className="flex flex-col gap-4">
+        <div>
+          <label className={labelClass}>Display name</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="How we'll greet you"
+            required
+            autoFocus
+            className={inputClass}
+          />
+        </div>
         <div>
           <label className={labelClass}>Email</label>
           <input
@@ -142,7 +150,6 @@ export default function Login() {
             onChange={(e) => setEmail(e.target.value)}
             placeholder="you@example.com"
             required
-            autoFocus
             className={inputClass}
           />
         </div>
@@ -150,7 +157,7 @@ export default function Login() {
           <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
         )}
         <button type="submit" disabled={loading} className={primaryBtnClass}>
-          {loading ? "Sending code..." : "Send sign-in code"}
+          {loading ? "Creating account..." : "Create account"}
         </button>
       </form>
     </AuthShell>


### PR DESCRIPTION
Update contracts to match current API: multi-step register (name+email → verify code) and login (email → confirmation key), trackings start without totalLength, UserProfile dropped isVerified, imageId threaded through library/catalog types.

Add /register, /mail (dev mailbox reader), and rewrite /login as a two-step flow that links users to the mailbox page to grab their code.

Redesign the UI around a paper-cream / ink theme with plum + amber accents and a Fraunces display font. Library gains status filters (reading/finished/not started) with counts; catalog filters now query the server with debounce; progress bars are click-to-edit; modal picks format via tiles; navbar greets the user by name.