### PR TITLE
CSRF frontend, Docker setup, configurable MongoDB/CORS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Local TLS certificates (generated per-machine for Docker)
+certs/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,83 @@
 ## Storygame
+
+A reading tracker application. Backend: ASP.NET Core 10. Frontend: React 19 with React Router 7. Database: MongoDB.
+
+---
+
+## Running with Docker
+
+The full stack runs as four containers: MongoDB, the .NET backend, the Node.js frontend, and an nginx reverse proxy. The proxy terminates TLS and routes `/api/*` to the backend and everything else to the frontend.
+
+### Prerequisites
+
+- Docker and Docker Compose installed
+- `openssl` available on your machine (comes with Git for Windows, macOS, and most Linux distributions)
+
+### 1. Generate a self-signed TLS certificate
+
+The application uses HTTPS-only cookies, so the proxy must serve HTTPS. Run this once from the project root:
+
+```bash
+mkdir certs
+openssl req -x509 -newkey rsa:4096 \
+  -keyout certs/key.pem \
+  -out certs/cert.pem \
+  -days 365 \
+  -nodes \
+  -subj "/CN=localhost"
+```
+
+### 2. Build and start the containers
+
+```bash
+docker compose up --build
+```
+
+The first build takes a few minutes — the .NET SDK image and npm dependencies need to be downloaded.
+
+### 3. Open the application
+
+Navigate to `https://localhost` in your browser. You will get a certificate warning because the cert is self-signed — accept it to proceed.
+
+To dismiss the warning in Chrome without clicking through: type `thisisunsafe` anywhere on the warning page.
+
+### 4. Stopping
+
+```bash
+docker compose down
+```
+
+MongoDB data is stored in a named Docker volume (`mongodb_data`) and persists between restarts. To remove it as well:
+
+```bash
+docker compose down -v
+```
+
+---
+
+## Local development (without Docker)
+
+### Requirements
+
+- .NET 10 SDK
+- Node.js 20+
+- MongoDB running on `localhost:27017`
+
+### Backend
+
+```bash
+cd src/Storygame.Web
+dotnet run
+```
+
+The API starts on `http://localhost:5263`.
+
+### Frontend
+
+```bash
+cd src/client
+npm install
+npm run dev
+```
+
+The dev server starts on `http://localhost:5173` and proxies `/api/*` to the backend.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  mongodb:
+    image: mongo:8
+    volumes:
+      - mongodb_data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  backend:
+    build:
+      context: ./src
+      dockerfile: Storygame.Web/Dockerfile
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Production
+      - ConnectionStrings__MongoDB=mongodb://mongodb:27017
+      - Cors__AllowedOrigins__0=https://localhost
+    depends_on:
+      mongodb:
+        condition: service_healthy
+
+  frontend:
+    build:
+      context: ./src/client
+    environment:
+      - PORT=3000
+    depends_on:
+      - backend
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./certs:/etc/nginx/certs:ro
+    depends_on:
+      - backend
+      - frontend
+
+volumes:
+  mongodb_data:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,29 @@
+server {
+    listen 443 ssl;
+    ssl_certificate /etc/nginx/certs/cert.pem;
+    ssl_certificate_key /etc/nginx/certs/key.pem;
+
+    location /api/ {
+        proxy_pass http://backend:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        proxy_pass http://frontend:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+
+server {
+    listen 80;
+    return 301 https://$host$request_uri;
+}

--- a/src/Storygame.Storage/StorageModule.cs
+++ b/src/Storygame.Storage/StorageModule.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Conventions;
@@ -15,29 +16,24 @@ namespace Storygame.Storage;
 
 public static class StorageModule
 {
-    public static void RegisterStorage(this IServiceCollection services)
+    public static void RegisterStorage(this IServiceCollection services, IConfiguration configuration)
     {
-        var mongoSettings = new MongoClientSettings() 
-        {
-            Server = new MongoServerAddress("localhost", 27017),
+        var connectionString = configuration.GetConnectionString("MongoDB") ?? "mongodb://localhost:27017";
+        var mongoSettings = MongoClientSettings.FromConnectionString(connectionString);
 
-            ConnectTimeout = TimeSpan.FromSeconds(10),
-            ServerSelectionTimeout = TimeSpan.FromSeconds(10),
-            SocketTimeout = TimeSpan.FromSeconds(30),
+        mongoSettings.ConnectTimeout = TimeSpan.FromSeconds(10);
+        mongoSettings.ServerSelectionTimeout = TimeSpan.FromSeconds(10);
+        mongoSettings.SocketTimeout = TimeSpan.FromSeconds(30);
+        mongoSettings.MaxConnectionPoolSize = 100;
+        mongoSettings.MinConnectionPoolSize = 0;
+        mongoSettings.MaxConnectionIdleTime = TimeSpan.FromMinutes(10);
+        mongoSettings.RetryWrites = true;
+        mongoSettings.RetryReads = true;
+        mongoSettings.ReadConcern = ReadConcern.Majority;
+        mongoSettings.WriteConcern = WriteConcern.WMajority;
+        mongoSettings.ReadPreference = ReadPreference.Primary;
+        mongoSettings.ApplicationName = "Storygame";
 
-            MaxConnectionPoolSize = 100,
-            MinConnectionPoolSize = 0,
-            MaxConnectionIdleTime = TimeSpan.FromMinutes(10),
-
-            RetryWrites = true,
-            RetryReads = true,
-
-            ReadConcern = ReadConcern.Majority,
-            WriteConcern = WriteConcern.WMajority,
-            ReadPreference = ReadPreference.Primary,
-
-            ApplicationName = "Storygame",
-        };
         var mongoClient = new MongoClient(mongoSettings);
         var database = mongoClient.GetDatabase("Storygame");
 

--- a/src/Storygame.Storage/Storygame.Storage.csproj
+++ b/src/Storygame.Storage/Storygame.Storage.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.7.1" />
   </ItemGroup>
 

--- a/src/Storygame.Web/Auth/AuthExtensions.cs
+++ b/src/Storygame.Web/Auth/AuthExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Extensions.Configuration;
 using System.Security.Claims;
 
 namespace Storygame.Web.Auth;
@@ -8,13 +9,16 @@ public static class AuthExtensions
 {
     public const string ActionIsRequestedByUserPolicy = "ActionIsRequestedByUser";
 
-    public static void ConfigureCors(this IServiceCollection services)
+    public static void ConfigureCors(this IServiceCollection services, IConfiguration configuration)
     {
+        var allowedOrigins = configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()
+            ?? ["http://localhost:5173"];
+
         services.AddCors(options =>
         {
             options.AddDefaultPolicy(policy =>
                 policy
-                    .WithOrigins("http://localhost:5173")
+                    .WithOrigins(allowedOrigins)
                     .WithMethods("GET", "POST")
                     .WithHeaders("Content-Type", "X-CSRF-TOKEN")
                     .AllowCredentials()

--- a/src/Storygame.Web/Dockerfile
+++ b/src/Storygame.Web/Dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish Storygame.Web/Storygame.Web.csproj -c Release -o /publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
+WORKDIR /app
+COPY --from=build /publish .
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "Storygame.Web.dll"]

--- a/src/Storygame.Web/Program.cs
+++ b/src/Storygame.Web/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.HttpOverrides;
 using MongoDB.Driver;
 using Storygame.Cqrs;
 using Storygame.Integrations.Email;
@@ -25,7 +26,7 @@ builder.Services.AddMemoryCache(options =>
     options.ExpirationScanFrequency = TimeSpan.FromMinutes(5);
 });
 
-builder.Services.ConfigureCors();
+builder.Services.ConfigureCors(builder.Configuration);
 
 builder.Services.AddControllers()
     .AddJsonOptions(opts =>
@@ -42,7 +43,7 @@ builder.Services.Configure<Microsoft.AspNetCore.Http.Json.JsonOptions>(opts =>
 builder.Services.AddOpenApi();
 
 builder.Services.RegisterCqrs();
-builder.Services.RegisterStorage();
+builder.Services.RegisterStorage(builder.Configuration);
 builder.Services.RegisterLogging();
 
 builder.Services.AddHealthChecks().AddMongoDb(sp => sp.GetRequiredService<IMongoClient>(), name: "MongoDB");
@@ -82,6 +83,14 @@ builder.Services.AddSwaggerGen();
 var app = builder.Build();
 
 StorageModule.Initialize();
+
+var forwardedHeadersOptions = new ForwardedHeadersOptions
+{
+    ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+};
+forwardedHeadersOptions.KnownNetworks.Clear();
+forwardedHeadersOptions.KnownProxies.Clear();
+app.UseForwardedHeaders(forwardedHeadersOptions);
 
 app.UseCors();
 

--- a/src/Storygame.Web/appsettings.json
+++ b/src/Storygame.Web/appsettings.json
@@ -5,5 +5,11 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "MongoDB": "mongodb://localhost:27017"
+  },
+  "Cors": {
+    "AllowedOrigins": [ "http://localhost:5173" ]
+  }
 }

--- a/src/client/Dockerfile
+++ b/src/client/Dockerfile
@@ -19,4 +19,5 @@ COPY ./package.json package-lock.json /app/
 COPY --from=production-dependencies-env /app/node_modules /app/node_modules
 COPY --from=build-env /app/build /app/build
 WORKDIR /app
+EXPOSE 3000
 CMD ["npm", "run", "start"]

--- a/src/client/app/api/client.ts
+++ b/src/client/app/api/client.ts
@@ -4,11 +4,34 @@ export class ApiError extends Error {
   }
 }
 
+let csrfToken: string | null = null;
+
+async function getCsrfToken(): Promise<string> {
+  if (csrfToken !== null) return csrfToken;
+  const res = await fetch("/api/users/CSRF", { credentials: "include" });
+  if (!res.ok) throw new ApiError(res.status, "Failed to fetch CSRF token");
+  csrfToken = await res.text();
+  return csrfToken;
+}
+
+export function resetCsrfToken(): void {
+  csrfToken = null;
+}
+
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...(init?.headers as Record<string, string>),
+  };
+
+  if (init?.method === "POST") {
+    headers["X-CSRF-TOKEN"] = await getCsrfToken();
+  }
+
   const res = await fetch(`/api${path}`, {
     credentials: "include",
-    headers: { "Content-Type": "application/json", ...init?.headers },
     ...init,
+    headers,
   });
 
   if (!res.ok) {

--- a/src/client/app/api/users.ts
+++ b/src/client/app/api/users.ts
@@ -1,4 +1,4 @@
-import { api } from "./client";
+import { api, resetCsrfToken } from "./client";
 import type { UserProfile } from "./types";
 
 export interface RegisterRequest {
@@ -24,7 +24,12 @@ export const usersApi = {
   register: (body: RegisterRequest) => api.post<void>("/users/Register", body),
   verify: (body: VerifyRequest) => api.post<void>("/users/Verify", body),
   login: (body: LoginRequest) => api.post<void>("/users/Login", body),
-  confirmLogin: (body: ConfirmLoginRequest) =>
-    api.post<void>("/users/ConfirmLogin", body),
-  logout: () => api.post<void>("/users/Logout"),
+  confirmLogin: async (body: ConfirmLoginRequest) => {
+    await api.post<void>("/users/ConfirmLogin", body);
+    resetCsrfToken();
+  },
+  logout: async () => {
+    await api.post<void>("/users/Logout");
+    resetCsrfToken();
+  },
 };


### PR DESCRIPTION
- Frontend now fetches CSRF token from GET /api/users/CSRF and includes X-CSRF-TOKEN header on every POST request. Token is reset after confirmLogin and logout because ASP.NET Core ties tokens to user identity.
- MongoDB connection string is now read from IConfiguration (ConnectionStrings:MongoDB), falling back to localhost:27017 for local dev.
- CORS allowed origins are now read from IConfiguration (Cors:AllowedOrigins).
- Added UseForwardedHeaders so the backend correctly detects HTTPS when running behind an nginx reverse proxy.
- Added Dockerfile for the backend (context: ./src).
- Added docker-compose.yml with mongodb, backend, frontend, and nginx services.
- nginx terminates TLS on port 443 and routes /api/* to the backend.
- README updated with step-by-step Docker and local dev instructions.
- certs/ added to .gitignore (self-signed cert generated per machine).