### PR TITLE
Add StorygameClient integration tests for CSRF and cookie handling

### DIFF
--- a/src/Storygame.Tests.Integration/Client/StorygameClientTests.cs
+++ b/src/Storygame.Tests.Integration/Client/StorygameClientTests.cs
@@ -1,11 +1,89 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Net.Http.Headers;
+using Storygame.Client;
+using Storygame.Contracts.WebApi;
+using Storygame.Contracts.WebApi.Requests;
 
 namespace Storygame.Tests.Integration.Client;
 
 [TestFixture]
 public class StorygameClientTests
 {
+    private WebApplicationFactory<Program> _factory = null!;
 
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder => builder.UseSetting("environment", "Development"));
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown() => _factory.Dispose();
+
+    private StorygameClient CreateClient()
+    {
+        var options = new WebApplicationFactoryClientOptions { BaseAddress = new Uri("https://localhost") };
+        return _factory.CreateClient(options).ToStorygameClient();
+    }
+
+    [Test]
+    public async Task Register_SetsXCsrfTokenInHeaders()
+    {
+        var client = CreateClient();
+        var (name, email) = NewCredentials();
+
+        await client.Register(new RegisterRequest(name, email));
+
+        Assert.That(client.HttpClient.DefaultRequestHeaders.Contains("X-CSRF-TOKEN"), Is.True);
+    }
+
+    [Test]
+    public async Task ConfirmLogin_SetsAuthCookieInHeaders()
+    {
+        var client = CreateClient();
+        var (name, email) = NewCredentials();
+
+        await RegisterAndVerify(client, name, email);
+        await PerformLogin(client, email);
+
+        Assert.That(client.HttpClient.DefaultRequestHeaders.TryGetValues(HeaderNames.Cookie, out var cookies), Is.True);
+        Assert.That(cookies!.Single(), Does.Contain("__Host-Auth"));
+    }
+
+    [Test]
+    public async Task AfterLogin_MeReturnsRegisteredUser()
+    {
+        var client = CreateClient();
+        var (name, email) = NewCredentials();
+
+        await RegisterAndVerify(client, name, email);
+        await PerformLogin(client, email);
+
+        var me = await client.Me();
+
+        Assert.That(me.Name, Is.EqualTo(name));
+    }
+
+    private static async Task RegisterAndVerify(StorygameClient client, string name, string email)
+    {
+        await client.Register(new RegisterRequest(name, email));
+        var mails = await client.Mail(email);
+        var verificationCode = mails.Single(m => m.Subject == "Verification code").Message;
+        await client.Verify(new VerifyUserRequest(email, verificationCode));
+    }
+
+    private static async Task PerformLogin(StorygameClient client, string email)
+    {
+        await client.Login(new LoginRequest(email));
+        var mails = await client.Mail(email);
+        var confirmationKey = mails.Single(m => m.Subject == "Login confirmation").Message;
+        await client.ConfirmLogin(new ConfirmLoginRequest(confirmationKey));
+    }
+
+    private static (string name, string email) NewCredentials()
+    {
+        var id = Guid.NewGuid().ToString("N");
+        return (id[..10], $"{id[..12]}@test.com");
+    }
 }


### PR DESCRIPTION
Tests verify that after login flow: X-CSRF-TOKEN is set in request headers after every POST, __Host-Auth cookie is stored after ConfirmLogin, and Me() returns the correct user (proving the cookie is sent with subsequent requests).