### PR TITLE
Refactor test infrastructure: mock repository, shared WebAppFactory c…

### DIFF
--- a/src/Storygame.Storage/StorageModule.cs
+++ b/src/Storygame.Storage/StorageModule.cs
@@ -44,8 +44,13 @@ public static class StorageModule
         services.AddSingleton<IUsersRepository, UsersRepository>();
     }
 
+    private static bool _initialized = false;
+
     public static void Initialize()
     {
+        if (_initialized) return;
+        _initialized = true;
+
         var pack = new ConventionPack
         {
             new CamelCaseElementNameConvention(),

--- a/src/Storygame.Tests.Integration/Client/StorygameClientTests.cs
+++ b/src/Storygame.Tests.Integration/Client/StorygameClientTests.cs
@@ -1,31 +1,18 @@
-using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Net.Http.Headers;
 using Storygame.Client;
 using Storygame.Contracts.WebApi;
 using Storygame.Contracts.WebApi.Requests;
+using Storygame.Users;
 
 namespace Storygame.Tests.Integration.Client;
 
 [TestFixture]
 public class StorygameClientTests
 {
-    private WebApplicationFactory<Program> _factory = null!;
-
-    [OneTimeSetUp]
-    public void OneTimeSetUp()
-    {
-        _factory = new WebApplicationFactory<Program>()
-            .WithWebHostBuilder(builder => builder.UseSetting("environment", "Development"));
-    }
-
-    [OneTimeTearDown]
-    public void OneTimeTearDown() => _factory.Dispose();
-
-    private StorygameClient CreateClient()
-    {
-        var options = new WebApplicationFactoryClientOptions { BaseAddress = new Uri("https://localhost") };
-        return _factory.CreateClient(options).ToStorygameClient();
-    }
+    private static StorygameClient CreateClient()
+        => WebAppFactory.CreateStorygameClient(services =>
+            services.AddSingleton<IUsersRepository>(new InMemoryUsersRepository()));
 
     [Test]
     public async Task Register_SetsXCsrfTokenInHeaders()

--- a/src/Storygame.Tests.Integration/InMemoryUsersRepository.cs
+++ b/src/Storygame.Tests.Integration/InMemoryUsersRepository.cs
@@ -1,0 +1,40 @@
+using Storygame.Users;
+using System.Collections.Concurrent;
+
+namespace Storygame.Tests.Integration;
+
+internal class InMemoryUsersRepository : IUsersRepository
+{
+    private readonly ConcurrentDictionary<Guid, User> _users = new();
+    private readonly ConcurrentDictionary<Guid, UserVerificationCode> _verificationCodes = new();
+
+    public Task AddUser(User user)
+    {
+        _users[user.Id] = user;
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateUser(User user)
+    {
+        _users[user.Id] = user;
+        return Task.CompletedTask;
+    }
+
+    public Task<User> GetUserById(Guid userId)
+        => Task.FromResult(_users[userId]);
+
+    public Task<User> GetUserByEmail(string email)
+        => Task.FromResult(_users.Values.Single(u => u.Email == email));
+
+    public Task<bool> CheckIfEmailExist(string email)
+        => Task.FromResult(_users.Values.Any(u => u.Email == email));
+
+    public Task SaveUserVerificationCode(UserVerificationCode verificationCode)
+    {
+        _verificationCodes[verificationCode.UserId] = verificationCode;
+        return Task.CompletedTask;
+    }
+
+    public Task<UserVerificationCode> GetUserVerificationCode(Guid userId)
+        => Task.FromResult(_verificationCodes[userId]);
+}

--- a/src/Storygame.Tests.Integration/WebAppFactory.cs
+++ b/src/Storygame.Tests.Integration/WebAppFactory.cs
@@ -9,15 +9,19 @@ public static class WebAppFactory
     public static HttpClient CreateHttpClient(Action<IServiceCollection>? customServices = null)
     {
         var factory = new WebApplicationFactory<Program>()
-            .WithWebHostBuilder(builder => 
+            .WithWebHostBuilder(builder =>
             {
-                builder.ConfigureServices(services => 
+                builder.UseSetting("environment", "Development");
+                builder.ConfigureServices(services =>
                 {
                     customServices?.Invoke(services);
                 });
             });
 
-        return factory.CreateClient();
+        return factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost")
+        });
     }
 
     public static StorygameClient CreateStorygameClient(Action<IServiceCollection>? customServices = null)


### PR DESCRIPTION
…onfig

- Make StorageModule.Initialize() idempotent so multiple WebApplicationFactory instances per test run don't crash on duplicate BSON serializer registration
- Move Development environment and https://localhost base address into WebAppFactory so tests don't need to manage factory setup themselves
- Add InMemoryUsersRepository to isolate tests from MongoDB
- Simplify StorygameClientTests to use WebAppFactory directly with mocked repository