### PR TITLE
Add unit tests for all command and query handlers

### DIFF
--- a/src/Storygame.Tests.Unit/Catalog/SearchCatalogQueryHandlerTests.cs
+++ b/src/Storygame.Tests.Unit/Catalog/SearchCatalogQueryHandlerTests.cs
@@ -1,0 +1,89 @@
+using Shouldly;
+using Storygame.Catalog.Queries;
+
+namespace Storygame.Tests.Unit.Catalog;
+
+[TestFixture]
+public class SearchCatalogQueryHandlerTests
+{
+    private SearchCatalogQueryHandler _handler = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _handler = new SearchCatalogQueryHandler();
+    }
+
+    [Test]
+    public async Task Returns_all_books_when_no_filters_are_applied()
+    {
+        var result = await _handler.HandleAsync(new SearchCatalogQuery(), CancellationToken.None);
+
+        result.Books.Count().ShouldBe(12);
+    }
+
+    [Test]
+    public async Task Filters_books_by_title_substring()
+    {
+        var result = await _handler.HandleAsync(new SearchCatalogQuery(TitleContains: "C#"), CancellationToken.None);
+
+        result.Books.Count().ShouldBe(2);
+        result.Books.ShouldAllBe(b => b.Title.Contains("C#"));
+    }
+
+    [Test]
+    public async Task Returns_only_books_with_audiobook_edition()
+    {
+        var result = await _handler.HandleAsync(new SearchCatalogQuery(HasAudiobook: true), CancellationToken.None);
+
+        result.Books.ShouldNotBeEmpty();
+        result.Books.ShouldAllBe(b => b.AudiobookFields.Exist);
+    }
+
+    [Test]
+    public async Task Returns_only_books_without_audiobook_edition()
+    {
+        var result = await _handler.HandleAsync(new SearchCatalogQuery(HasAudiobook: false), CancellationToken.None);
+
+        result.Books.ShouldNotBeEmpty();
+        result.Books.ShouldAllBe(b => !b.AudiobookFields.Exist);
+    }
+
+    [Test]
+    public async Task Audiobook_and_non_audiobook_results_sum_to_all_books()
+    {
+        var withAudiobook = await _handler.HandleAsync(new SearchCatalogQuery(HasAudiobook: true), CancellationToken.None);
+        var withoutAudiobook = await _handler.HandleAsync(new SearchCatalogQuery(HasAudiobook: false), CancellationToken.None);
+        var all = await _handler.HandleAsync(new SearchCatalogQuery(), CancellationToken.None);
+
+        (withAudiobook.Books.Count() + withoutAudiobook.Books.Count()).ShouldBe(all.Books.Count());
+    }
+
+    [Test]
+    public async Task Returns_empty_when_title_filter_matches_nothing()
+    {
+        var result = await _handler.HandleAsync(
+            new SearchCatalogQuery(TitleContains: "DefinitelyNotInCatalog"), CancellationToken.None);
+
+        result.Books.ShouldBeEmpty();
+    }
+
+    [Test]
+    public async Task Combines_title_and_audiobook_filters()
+    {
+        var result = await _handler.HandleAsync(
+            new SearchCatalogQuery(TitleContains: "The", HasAudiobook: true), CancellationToken.None);
+
+        result.Books.ShouldAllBe(b => b.Title.Contains("The") && b.AudiobookFields.Exist);
+    }
+
+    [Test]
+    public async Task Throws_when_cancellation_is_requested_before_execution()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Should.ThrowAsync<OperationCanceledException>(() =>
+            _handler.HandleAsync(new SearchCatalogQuery(), cts.Token));
+    }
+}

--- a/src/Storygame.Tests.Unit/Library/AddBookToLibraryCommandHandlerTests.cs
+++ b/src/Storygame.Tests.Unit/Library/AddBookToLibraryCommandHandlerTests.cs
@@ -1,0 +1,120 @@
+using Moq;
+using Shouldly;
+using Storygame.Cqrs;
+using Storygame.Library;
+using Storygame.Library.Commands;
+using Storygame.Library.Events;
+
+namespace Storygame.Tests.Unit.Library;
+
+[TestFixture]
+public class AddBookToLibraryCommandHandlerTests
+{
+    private Mock<ILibraryRepository> _repository = null!;
+    private Mock<IDispatcher> _dispatcher = null!;
+    private AddBookToLibraryCommandHandler _handler = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repository = new Mock<ILibraryRepository>();
+        _dispatcher = new Mock<IDispatcher>();
+        _handler = new AddBookToLibraryCommandHandler(_repository.Object, _dispatcher.Object);
+    }
+
+    [Test]
+    public async Task Throws_when_user_already_has_the_same_book_in_the_same_format()
+    {
+        var command = AnyCommand();
+
+        _repository
+            .Setup(r => r.CheckIfUserAlreadyHasThisBook(command.UserId, command.CatalogBookId!.Value, command.MediaType, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        await Should.ThrowAsync<ArgumentException>(() => _handler.HandleAsync(command, CancellationToken.None));
+    }
+
+    [Test]
+    public async Task Does_not_check_for_duplicates_when_catalog_book_id_is_null()
+    {
+        var command = AnyCommand() with { CatalogBookId = null };
+
+        await _handler.HandleAsync(command, CancellationToken.None);
+
+        _repository.Verify(
+            r => r.CheckIfUserAlreadyHasThisBook(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<MediaType>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task Saves_book_with_properties_from_the_command()
+    {
+        var imageId = Guid.NewGuid();
+        var command = new AddBookToLibraryCommand(Guid.NewGuid(), Guid.NewGuid(), imageId, "Dune", "Classic sci-fi", MediaType.Ebook, 412);
+
+        _repository
+            .Setup(r => r.CheckIfUserAlreadyHasThisBook(command.UserId, command.CatalogBookId!.Value, command.MediaType, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        Book? savedBook = null;
+        _repository
+            .Setup(r => r.AddBook(It.IsAny<Book>(), It.IsAny<CancellationToken>()))
+            .Callback<Book, CancellationToken>((book, _) => savedBook = book);
+
+        await _handler.HandleAsync(command, CancellationToken.None);
+
+        savedBook.ShouldNotBeNull();
+        savedBook.Id.ShouldNotBe(Guid.Empty);
+        savedBook.UserId.ShouldBe(command.UserId);
+        savedBook.CatalogBookId.ShouldBe(command.CatalogBookId);
+        savedBook.ImageId.ShouldBe(imageId);
+        savedBook.Title.ShouldBe("Dune");
+        savedBook.Description.ShouldBe("Classic sci-fi");
+        savedBook.MediaType.ShouldBe(MediaType.Ebook);
+        savedBook.Length.ShouldBe(412);
+        savedBook.AddedToLibraryAt.ShouldBeInRange(DateTime.UtcNow.AddSeconds(-5), DateTime.UtcNow);
+    }
+
+    [Test]
+    public async Task Publishes_event_with_data_matching_the_saved_book()
+    {
+        var command = AnyCommand();
+
+        _repository
+            .Setup(r => r.CheckIfUserAlreadyHasThisBook(command.UserId, command.CatalogBookId!.Value, command.MediaType, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        BookAddedToLibraryEvent? publishedEvent = null;
+        _dispatcher
+            .Setup(d => d.PublishAsync(It.IsAny<BookAddedToLibraryEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<BookAddedToLibraryEvent, CancellationToken>((e, _) => publishedEvent = e);
+
+        await _handler.HandleAsync(command, CancellationToken.None);
+
+        publishedEvent.ShouldNotBeNull();
+        publishedEvent.LibraryBookId.ShouldNotBe(Guid.Empty);
+        publishedEvent.UserId.ShouldBe(command.UserId);
+        publishedEvent.CatalogBookId.ShouldBe(command.CatalogBookId);
+        publishedEvent.Title.ShouldBe(command.Title);
+        publishedEvent.MediaType.ShouldBe(command.MediaType);
+    }
+
+    [Test]
+    public async Task Does_not_publish_event_when_duplicate_is_detected()
+    {
+        var command = AnyCommand();
+
+        _repository
+            .Setup(r => r.CheckIfUserAlreadyHasThisBook(command.UserId, command.CatalogBookId!.Value, command.MediaType, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        await Should.ThrowAsync<ArgumentException>(() => _handler.HandleAsync(command, CancellationToken.None));
+
+        _dispatcher.Verify(
+            d => d.PublishAsync(It.IsAny<BookAddedToLibraryEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static AddBookToLibraryCommand AnyCommand()
+        => new(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "Dune", "Classic sci-fi", MediaType.Ebook, 412);
+}

--- a/src/Storygame.Tests.Unit/Library/GetLibraryBookByIdQueryHandlerTests.cs
+++ b/src/Storygame.Tests.Unit/Library/GetLibraryBookByIdQueryHandlerTests.cs
@@ -1,0 +1,55 @@
+using Moq;
+using Shouldly;
+using Storygame.Library;
+using Storygame.Library.Queries;
+
+namespace Storygame.Tests.Unit.Library;
+
+[TestFixture]
+public class GetLibraryBookByIdQueryHandlerTests
+{
+    private Mock<ILibraryRepository> _repository = null!;
+    private GetLibraryBookByIdQueryHandler _handler = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repository = new Mock<ILibraryRepository>();
+        _handler = new GetLibraryBookByIdQueryHandler(_repository.Object);
+    }
+
+    [Test]
+    public async Task Returns_book_for_given_id_and_user()
+    {
+        var bookId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var book = AnyBook(bookId, userId);
+
+        _repository.Setup(r => r.GetBookById(bookId, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(book);
+
+        var result = await _handler.HandleAsync(new GetLibraryBookByIdQuery(bookId, userId), CancellationToken.None);
+
+        result.Book.ShouldBe(book);
+    }
+
+    [Test]
+    public async Task Passes_both_book_id_and_user_id_to_repository()
+    {
+        var bookId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        _repository.Setup(r => r.GetBookById(bookId, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(AnyBook(bookId, userId));
+
+        await _handler.HandleAsync(new GetLibraryBookByIdQuery(bookId, userId), CancellationToken.None);
+
+        _repository.Verify(r => r.GetBookById(bookId, userId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static Book AnyBook(Guid id, Guid userId) => new()
+    {
+        Id = id, UserId = userId, CatalogBookId = null, ImageId = null,
+        Title = "Dune", Description = "Classic sci-fi", MediaType = MediaType.Ebook,
+        Length = 412, AddedToLibraryAt = DateTime.UtcNow
+    };
+}

--- a/src/Storygame.Tests.Unit/Library/GetUserBooksFromLibraryQueryHandlerTests.cs
+++ b/src/Storygame.Tests.Unit/Library/GetUserBooksFromLibraryQueryHandlerTests.cs
@@ -1,0 +1,53 @@
+using Moq;
+using Shouldly;
+using Storygame.Library;
+using Storygame.Library.Queries;
+
+namespace Storygame.Tests.Unit.Library;
+
+[TestFixture]
+public class GetUserBooksFromLibraryQueryHandlerTests
+{
+    private Mock<ILibraryRepository> _repository = null!;
+    private GetUserBooksFromLibraryQueryHandler _handler = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repository = new Mock<ILibraryRepository>();
+        _handler = new GetUserBooksFromLibraryQueryHandler(_repository.Object);
+    }
+
+    [Test]
+    public async Task Returns_all_books_belonging_to_user()
+    {
+        var userId = Guid.NewGuid();
+        var books = new List<Book> { AnyBook(userId), AnyBook(userId) };
+
+        _repository.Setup(r => r.GetUserBooks(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(books);
+
+        var result = await _handler.HandleAsync(new GetUserBooksFromLibraryQuery(userId), CancellationToken.None);
+
+        result.Books.ShouldBe(books);
+    }
+
+    [Test]
+    public async Task Returns_empty_collection_when_user_has_no_books()
+    {
+        var userId = Guid.NewGuid();
+        _repository.Setup(r => r.GetUserBooks(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<Book>());
+
+        var result = await _handler.HandleAsync(new GetUserBooksFromLibraryQuery(userId), CancellationToken.None);
+
+        result.Books.ShouldBeEmpty();
+    }
+
+    private static Book AnyBook(Guid userId) => new()
+    {
+        Id = Guid.NewGuid(), UserId = userId, CatalogBookId = null, ImageId = null,
+        Title = "Dune", Description = "Classic sci-fi", MediaType = MediaType.Ebook,
+        Length = 412, AddedToLibraryAt = DateTime.UtcNow
+    };
+}

--- a/src/Storygame.Tests.Unit/Storygame.Tests.Unit.csproj
+++ b/src/Storygame.Tests.Unit/Storygame.Tests.Unit.csproj
@@ -14,12 +14,21 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.6.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Storygame.Catalog\Storygame.Catalog.csproj" />
+    <ProjectReference Include="..\Storygame.Library\Storygame.Library.csproj" />
+    <ProjectReference Include="..\Storygame.Tracking\Storygame.Tracking.csproj" />
+    <ProjectReference Include="..\Storygame.Users\Storygame.Users.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Storygame.Tests.Unit/Tracking/GetTrackingStatisticsQueryHandlerTests.cs
+++ b/src/Storygame.Tests.Unit/Tracking/GetTrackingStatisticsQueryHandlerTests.cs
@@ -1,0 +1,69 @@
+using Moq;
+using Shouldly;
+using Storygame.Tracking;
+using Storygame.Tracking.Queries;
+
+namespace Storygame.Tests.Unit.Tracking;
+
+[TestFixture]
+public class GetTrackingStatisticsQueryHandlerTests
+{
+    private Mock<ITrackingRepository> _repository = null!;
+    private GetTrackingStatisticsQueryHandler _handler = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repository = new Mock<ITrackingRepository>();
+        _handler = new GetTrackingStatisticsQueryHandler(_repository.Object);
+    }
+
+    [Test]
+    public async Task Returns_statistics_for_given_tracking_and_time_range()
+    {
+        var trackingId = Guid.NewGuid();
+        var timeRange = new TimeRange(DateTime.UtcNow.AddDays(-7), DateTime.UtcNow);
+        var statistics = new List<TrackingStatistic>
+        {
+            new() { Id = Guid.NewGuid(), TrackingId = trackingId, TimePeriod = TimePeriod.Day, TimeRange = timeRange, Value = 30 },
+            new() { Id = Guid.NewGuid(), TrackingId = trackingId, TimePeriod = TimePeriod.Day, TimeRange = timeRange, Value = 45 }
+        };
+
+        _repository.Setup(r => r.GetStatistics(trackingId, timeRange, TimePeriod.Day, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(statistics);
+
+        var result = await _handler.HandleAsync(
+            new GetTrackingStatisticsQuery(trackingId, timeRange, TimePeriod.Day), CancellationToken.None);
+
+        result.TrackingStatistics.ShouldBe(statistics);
+    }
+
+    [Test]
+    public async Task Returns_empty_when_no_statistics_exist_for_given_period()
+    {
+        var trackingId = Guid.NewGuid();
+        var timeRange = new TimeRange(DateTime.UtcNow.AddMonths(-1), DateTime.UtcNow);
+
+        _repository.Setup(r => r.GetStatistics(trackingId, timeRange, TimePeriod.Month, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<TrackingStatistic>());
+
+        var result = await _handler.HandleAsync(
+            new GetTrackingStatisticsQuery(trackingId, timeRange, TimePeriod.Month), CancellationToken.None);
+
+        result.TrackingStatistics.ShouldBeEmpty();
+    }
+
+    [Test]
+    public async Task Passes_all_query_parameters_to_repository()
+    {
+        var trackingId = Guid.NewGuid();
+        var timeRange = new TimeRange(DateTime.UtcNow.AddDays(-30), DateTime.UtcNow);
+
+        _repository.Setup(r => r.GetStatistics(It.IsAny<Guid>(), It.IsAny<TimeRange>(), It.IsAny<TimePeriod>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<TrackingStatistic>());
+
+        await _handler.HandleAsync(new GetTrackingStatisticsQuery(trackingId, timeRange, TimePeriod.Week), CancellationToken.None);
+
+        _repository.Verify(r => r.GetStatistics(trackingId, timeRange, TimePeriod.Week, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/src/Storygame.Tests.Unit/Tracking/GetUserTrackingsQueryHandlerTests.cs
+++ b/src/Storygame.Tests.Unit/Tracking/GetUserTrackingsQueryHandlerTests.cs
@@ -1,0 +1,51 @@
+using Moq;
+using Shouldly;
+using Storygame.Tracking;
+using Storygame.Tracking.Queries;
+using TrackingEntry = Storygame.Tracking.Tracking;
+
+namespace Storygame.Tests.Unit.Tracking;
+
+[TestFixture]
+public class GetUserTrackingsQueryHandlerTests
+{
+    private Mock<ITrackingRepository> _repository = null!;
+    private GetUserTrackingsQueryHandler _handler = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repository = new Mock<ITrackingRepository>();
+        _handler = new GetUserTrackingsQueryHandler(_repository.Object);
+    }
+
+    [Test]
+    public async Task Returns_all_trackings_for_user()
+    {
+        var userId = Guid.NewGuid();
+        var trackings = new List<TrackingEntry>
+        {
+            new() { Id = Guid.NewGuid(), LibraryBookId = Guid.NewGuid(), UserId = userId, TotalLength = 300, CurrentIndex = 100 },
+            new() { Id = Guid.NewGuid(), LibraryBookId = Guid.NewGuid(), UserId = userId, TotalLength = 420, CurrentIndex = 0 }
+        };
+
+        _repository.Setup(r => r.GetUserTrackings(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(trackings);
+
+        var result = await _handler.HandleAsync(new GetUserTrackingsQuery(userId), CancellationToken.None);
+
+        result.Trackings.ShouldBe(trackings);
+    }
+
+    [Test]
+    public async Task Returns_empty_collection_when_user_has_no_trackings()
+    {
+        var userId = Guid.NewGuid();
+        _repository.Setup(r => r.GetUserTrackings(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<TrackingEntry>());
+
+        var result = await _handler.HandleAsync(new GetUserTrackingsQuery(userId), CancellationToken.None);
+
+        result.Trackings.ShouldBeEmpty();
+    }
+}

--- a/src/Storygame.Tests.Unit/Tracking/StartTrackingBookCommandHandlerTests.cs
+++ b/src/Storygame.Tests.Unit/Tracking/StartTrackingBookCommandHandlerTests.cs
@@ -1,0 +1,105 @@
+using Moq;
+using Shouldly;
+using Storygame.Cqrs;
+using Storygame.Tracking;
+using Storygame.Tracking.Commands;
+using Storygame.Tracking.Events;
+using TrackingEntry = Storygame.Tracking.Tracking;
+
+namespace Storygame.Tests.Unit.Tracking;
+
+[TestFixture]
+public class StartTrackingBookCommandHandlerTests
+{
+    private Mock<ITrackingRepository> _repository = null!;
+    private Mock<IDispatcher> _dispatcher = null!;
+    private StartTrackingBookCommandHandler _handler = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repository = new Mock<ITrackingRepository>();
+        _dispatcher = new Mock<IDispatcher>();
+        _handler = new StartTrackingBookCommandHandler(_repository.Object, _dispatcher.Object);
+    }
+
+    [Test]
+    public async Task Throws_when_book_is_already_being_tracked()
+    {
+        var command = AnyCommand();
+        _repository.Setup(r => r.CheckIfBookIsAlreadyTracked(command.LibraryBookId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        await Should.ThrowAsync<ArgumentException>(() => _handler.HandleAsync(command, CancellationToken.None));
+    }
+
+    [Test]
+    public async Task Saves_tracking_with_zero_initial_progress()
+    {
+        var command = AnyCommand();
+        _repository.Setup(r => r.CheckIfBookIsAlreadyTracked(command.LibraryBookId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        TrackingEntry? savedTracking = null;
+        _repository.Setup(r => r.AddTracking(It.IsAny<TrackingEntry>(), It.IsAny<CancellationToken>()))
+            .Callback<TrackingEntry, CancellationToken>((t, _) => savedTracking = t);
+
+        await _handler.HandleAsync(command, CancellationToken.None);
+
+        savedTracking.ShouldNotBeNull();
+        savedTracking.Id.ShouldNotBe(Guid.Empty);
+        savedTracking.LibraryBookId.ShouldBe(command.LibraryBookId);
+        savedTracking.UserId.ShouldBe(command.UserId);
+        savedTracking.TotalLength.ShouldBe(command.TotalLength);
+        savedTracking.CurrentIndex.ShouldBe(0);
+    }
+
+    [Test]
+    public async Task Publishes_event_with_tracking_data_after_starting()
+    {
+        var command = AnyCommand();
+        _repository.Setup(r => r.CheckIfBookIsAlreadyTracked(command.LibraryBookId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        TrackingStartedEvent? publishedEvent = null;
+        _dispatcher.Setup(d => d.PublishAsync(It.IsAny<TrackingStartedEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<TrackingStartedEvent, CancellationToken>((e, _) => publishedEvent = e);
+
+        await _handler.HandleAsync(command, CancellationToken.None);
+
+        publishedEvent.ShouldNotBeNull();
+        publishedEvent.TrackingId.ShouldNotBe(Guid.Empty);
+        publishedEvent.LibraryBookId.ShouldBe(command.LibraryBookId);
+        publishedEvent.UserId.ShouldBe(command.UserId);
+        publishedEvent.TotalLength.ShouldBe(command.TotalLength);
+    }
+
+    [Test]
+    public async Task Does_not_publish_event_when_book_is_already_tracked()
+    {
+        var command = AnyCommand();
+        _repository.Setup(r => r.CheckIfBookIsAlreadyTracked(command.LibraryBookId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        await Should.ThrowAsync<ArgumentException>(() => _handler.HandleAsync(command, CancellationToken.None));
+
+        _dispatcher.Verify(
+            d => d.PublishAsync(It.IsAny<TrackingStartedEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task Does_not_save_tracking_when_book_is_already_tracked()
+    {
+        var command = AnyCommand();
+        _repository.Setup(r => r.CheckIfBookIsAlreadyTracked(command.LibraryBookId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        await Should.ThrowAsync<ArgumentException>(() => _handler.HandleAsync(command, CancellationToken.None));
+
+        _repository.Verify(r => r.AddTracking(It.IsAny<TrackingEntry>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static StartTrackingBookCommand AnyCommand()
+        => new(Guid.NewGuid(), Guid.NewGuid(), 412);
+}

--- a/src/Storygame.Tests.Unit/Tracking/UpdateTrackingIndexCommandHandlerTests.cs
+++ b/src/Storygame.Tests.Unit/Tracking/UpdateTrackingIndexCommandHandlerTests.cs
@@ -1,0 +1,113 @@
+using Moq;
+using Shouldly;
+using Storygame.Cqrs;
+using Storygame.Ownership;
+using Storygame.Tracking;
+using Storygame.Tracking.Commands;
+using Storygame.Tracking.Events;
+using TrackingEntry = Storygame.Tracking.Tracking;
+
+namespace Storygame.Tests.Unit.Tracking;
+
+[TestFixture]
+public class UpdateTrackingIndexCommandHandlerTests
+{
+    private Mock<ITrackingRepository> _repository = null!;
+    private Mock<IDispatcher> _dispatcher = null!;
+    private UpdateTrackingIndexCommandHandler _handler = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repository = new Mock<ITrackingRepository>();
+        _dispatcher = new Mock<IDispatcher>();
+        _handler = new UpdateTrackingIndexCommandHandler(_repository.Object, _dispatcher.Object);
+    }
+
+    [Test]
+    public async Task Throws_when_user_is_not_the_owner_of_tracking()
+    {
+        var tracking = AnyTracking(ownedBy: Guid.NewGuid());
+        _repository.Setup(r => r.GetTracking(tracking.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tracking);
+
+        var command = new UpdateTrackingIndexCommand(Guid.NewGuid(), tracking.Id, 100);
+
+        await Should.ThrowAsync<OwnershipException>(() => _handler.HandleAsync(command, CancellationToken.None));
+    }
+
+    [Test]
+    public async Task Updates_current_index_to_the_new_value()
+    {
+        var userId = Guid.NewGuid();
+        var tracking = AnyTracking(ownedBy: userId, currentIndex: 50);
+        _repository.Setup(r => r.GetTracking(tracking.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tracking);
+
+        TrackingEntry? updatedTracking = null;
+        _repository.Setup(r => r.UpdateTracking(It.IsAny<TrackingEntry>(), It.IsAny<CancellationToken>()))
+            .Callback<TrackingEntry, CancellationToken>((t, _) => updatedTracking = t);
+
+        await _handler.HandleAsync(new UpdateTrackingIndexCommand(userId, tracking.Id, 120), CancellationToken.None);
+
+        updatedTracking.ShouldNotBeNull();
+        updatedTracking.CurrentIndex.ShouldBe(120);
+    }
+
+    [Test]
+    public async Task Publishes_event_with_old_and_new_index()
+    {
+        var userId = Guid.NewGuid();
+        var tracking = AnyTracking(ownedBy: userId, currentIndex: 50);
+        _repository.Setup(r => r.GetTracking(tracking.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tracking);
+
+        TrackingIndexUpdatedEvent? publishedEvent = null;
+        _dispatcher.Setup(d => d.PublishAsync(It.IsAny<TrackingIndexUpdatedEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<TrackingIndexUpdatedEvent, CancellationToken>((e, _) => publishedEvent = e);
+
+        await _handler.HandleAsync(new UpdateTrackingIndexCommand(userId, tracking.Id, 120), CancellationToken.None);
+
+        publishedEvent.ShouldNotBeNull();
+        publishedEvent.TrackingId.ShouldBe(tracking.Id);
+        publishedEvent.OldIndex.ShouldBe(50);
+        publishedEvent.NewIndex.ShouldBe(120);
+    }
+
+    [Test]
+    public async Task Does_not_update_repository_when_user_is_not_the_owner()
+    {
+        var tracking = AnyTracking(ownedBy: Guid.NewGuid());
+        _repository.Setup(r => r.GetTracking(tracking.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tracking);
+
+        await Should.ThrowAsync<OwnershipException>(() =>
+            _handler.HandleAsync(new UpdateTrackingIndexCommand(Guid.NewGuid(), tracking.Id, 100), CancellationToken.None));
+
+        _repository.Verify(r => r.UpdateTracking(It.IsAny<TrackingEntry>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Does_not_publish_event_when_user_is_not_the_owner()
+    {
+        var tracking = AnyTracking(ownedBy: Guid.NewGuid());
+        _repository.Setup(r => r.GetTracking(tracking.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tracking);
+
+        await Should.ThrowAsync<OwnershipException>(() =>
+            _handler.HandleAsync(new UpdateTrackingIndexCommand(Guid.NewGuid(), tracking.Id, 100), CancellationToken.None));
+
+        _dispatcher.Verify(
+            d => d.PublishAsync(It.IsAny<TrackingIndexUpdatedEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static TrackingEntry AnyTracking(Guid ownedBy, int currentIndex = 0) => new()
+    {
+        Id = Guid.NewGuid(),
+        LibraryBookId = Guid.NewGuid(),
+        UserId = ownedBy,
+        TotalLength = 412,
+        CurrentIndex = currentIndex
+    };
+}

--- a/src/Storygame.Tests.Unit/Users/GetUserByEmailQueryHandlerTests.cs
+++ b/src/Storygame.Tests.Unit/Users/GetUserByEmailQueryHandlerTests.cs
@@ -1,0 +1,52 @@
+using Moq;
+using Shouldly;
+using Storygame.Users;
+using Storygame.Users.Queries;
+
+namespace Storygame.Tests.Unit.Users;
+
+[TestFixture]
+public class GetUserByEmailQueryHandlerTests
+{
+    private Mock<IUsersRepository> _repository = null!;
+    private GetUserByEmailQueryHandler _handler = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repository = new Mock<IUsersRepository>();
+        _handler = new GetUserByEmailQueryHandler(_repository.Object);
+    }
+
+    [Test]
+    public async Task Returns_user_matching_given_email()
+    {
+        var user = new User
+        {
+            Id = Guid.NewGuid(), Name = "Jan Kowalski", Email = "jan@example.com",
+            RegisteredAt = DateTime.UtcNow, VerifiedAt = null
+        };
+        _repository.Setup(r => r.GetUserByEmail("jan@example.com", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        var result = await _handler.HandleAsync(new GetUserByEmailQuery("jan@example.com"), CancellationToken.None);
+
+        result.User.ShouldBe(user);
+    }
+
+    [Test]
+    public async Task Passes_email_to_repository_without_modification()
+    {
+        var user = new User
+        {
+            Id = Guid.NewGuid(), Name = "Anna", Email = "anna@example.com",
+            RegisteredAt = DateTime.UtcNow, VerifiedAt = null
+        };
+        _repository.Setup(r => r.GetUserByEmail("anna@example.com", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        await _handler.HandleAsync(new GetUserByEmailQuery("anna@example.com"), CancellationToken.None);
+
+        _repository.Verify(r => r.GetUserByEmail("anna@example.com", It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/src/Storygame.Tests.Unit/Users/GetUserByIdQueryHandlerTests.cs
+++ b/src/Storygame.Tests.Unit/Users/GetUserByIdQueryHandlerTests.cs
@@ -1,0 +1,53 @@
+using Moq;
+using Shouldly;
+using Storygame.Users;
+using Storygame.Users.Queries;
+
+namespace Storygame.Tests.Unit.Users;
+
+[TestFixture]
+public class GetUserByIdQueryHandlerTests
+{
+    private Mock<IUsersRepository> _repository = null!;
+    private GetUserByIdQueryHandler _handler = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repository = new Mock<IUsersRepository>();
+        _handler = new GetUserByIdQueryHandler(_repository.Object);
+    }
+
+    [Test]
+    public async Task Returns_user_matching_given_id()
+    {
+        var userId = Guid.NewGuid();
+        var user = new User
+        {
+            Id = userId, Name = "Jan Kowalski", Email = "jan@example.com",
+            RegisteredAt = DateTime.UtcNow, VerifiedAt = null
+        };
+        _repository.Setup(r => r.GetUserById(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        var result = await _handler.HandleAsync(new GetUserByIdQuery(userId), CancellationToken.None);
+
+        result.User.ShouldBe(user);
+    }
+
+    [Test]
+    public async Task Passes_user_id_to_repository_without_modification()
+    {
+        var userId = Guid.NewGuid();
+        var user = new User
+        {
+            Id = userId, Name = "Jan", Email = "jan@example.com",
+            RegisteredAt = DateTime.UtcNow, VerifiedAt = null
+        };
+        _repository.Setup(r => r.GetUserById(userId, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+
+        await _handler.HandleAsync(new GetUserByIdQuery(userId), CancellationToken.None);
+
+        _repository.Verify(r => r.GetUserById(userId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/src/Storygame.Tests.Unit/Users/RegisterUserCommandHandlerTests.cs
+++ b/src/Storygame.Tests.Unit/Users/RegisterUserCommandHandlerTests.cs
@@ -1,0 +1,124 @@
+using Moq;
+using Shouldly;
+using Storygame.Cqrs;
+using Storygame.Integrations.Email;
+using Storygame.Users;
+using Storygame.Users.Commands;
+using Storygame.Users.Events;
+
+namespace Storygame.Tests.Unit.Users;
+
+[TestFixture]
+public class RegisterUserCommandHandlerTests
+{
+    private Mock<IUsersRepository> _repository = null!;
+    private EmailClient _emailClient = null!;
+    private Mock<IDispatcher> _dispatcher = null!;
+    private RegisterUserCommandHandler _handler = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repository = new Mock<IUsersRepository>();
+        _emailClient = new EmailClient();
+        _dispatcher = new Mock<IDispatcher>();
+        _handler = new RegisterUserCommandHandler(_repository.Object, _emailClient, _dispatcher.Object);
+    }
+
+    [Test]
+    public async Task Throws_when_email_is_already_registered()
+    {
+        _repository.Setup(r => r.CheckIfEmailExist("jan@example.com", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        await Should.ThrowAsync<ArgumentException>(() =>
+            _handler.HandleAsync(new RegisterUserCommand("Jan", "jan@example.com"), CancellationToken.None));
+    }
+
+    [Test]
+    public async Task Saves_user_with_data_from_command()
+    {
+        _repository.Setup(r => r.CheckIfEmailExist(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        User? savedUser = null;
+        _repository.Setup(r => r.AddUser(It.IsAny<User>(), It.IsAny<CancellationToken>()))
+            .Callback<User, CancellationToken>((u, _) => savedUser = u);
+
+        await _handler.HandleAsync(new RegisterUserCommand("Jan Kowalski", "jan@example.com"), CancellationToken.None);
+
+        savedUser.ShouldNotBeNull();
+        savedUser.Id.ShouldNotBe(Guid.Empty);
+        savedUser.Name.ShouldBe("Jan Kowalski");
+        savedUser.Email.ShouldBe("jan@example.com");
+        savedUser.VerifiedAt.ShouldBeNull();
+        savedUser.RegisteredAt.ShouldBeInRange(DateTime.UtcNow.AddSeconds(-5), DateTime.UtcNow);
+    }
+
+    [Test]
+    public async Task Saves_verification_code_linked_to_the_new_user()
+    {
+        _repository.Setup(r => r.CheckIfEmailExist(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        User? savedUser = null;
+        _repository.Setup(r => r.AddUser(It.IsAny<User>(), It.IsAny<CancellationToken>()))
+            .Callback<User, CancellationToken>((u, _) => savedUser = u);
+
+        UserVerificationCode? savedCode = null;
+        _repository.Setup(r => r.SaveUserVerificationCode(It.IsAny<UserVerificationCode>(), It.IsAny<CancellationToken>()))
+            .Callback<UserVerificationCode, CancellationToken>((c, _) => savedCode = c);
+
+        await _handler.HandleAsync(new RegisterUserCommand("Jan", "jan@example.com"), CancellationToken.None);
+
+        savedCode.ShouldNotBeNull();
+        savedCode.Id.ShouldNotBe(Guid.Empty);
+        savedCode.UserId.ShouldBe(savedUser!.Id);
+        savedCode.Code.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public async Task Sends_verification_email_to_the_registered_address()
+    {
+        _repository.Setup(r => r.CheckIfEmailExist(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        await _handler.HandleAsync(new RegisterUserCommand("Jan", "jan@example.com"), CancellationToken.None);
+
+        var sentMessages = await _emailClient.Read("jan@example.com");
+        sentMessages.Length.ShouldBe(1);
+        sentMessages[0].Receiver.ShouldBe("jan@example.com");
+    }
+
+    [Test]
+    public async Task Publishes_event_with_user_data_after_registration()
+    {
+        _repository.Setup(r => r.CheckIfEmailExist(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        UserRegisteredEvent? publishedEvent = null;
+        _dispatcher.Setup(d => d.PublishAsync(It.IsAny<UserRegisteredEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<UserRegisteredEvent, CancellationToken>((e, _) => publishedEvent = e);
+
+        await _handler.HandleAsync(new RegisterUserCommand("Jan Kowalski", "jan@example.com"), CancellationToken.None);
+
+        publishedEvent.ShouldNotBeNull();
+        publishedEvent.UserId.ShouldNotBe(Guid.Empty);
+        publishedEvent.Name.ShouldBe("Jan Kowalski");
+        publishedEvent.Email.ShouldBe("jan@example.com");
+    }
+
+    [Test]
+    public async Task Does_not_publish_event_when_email_already_exists()
+    {
+        _repository.Setup(r => r.CheckIfEmailExist(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        await Should.ThrowAsync<ArgumentException>(() =>
+            _handler.HandleAsync(new RegisterUserCommand("Jan", "jan@example.com"), CancellationToken.None));
+
+        _dispatcher.Verify(
+            d => d.PublishAsync(It.IsAny<UserRegisteredEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/src/Storygame.Tests.Unit/Users/VerifyUserCommandHandlerTests.cs
+++ b/src/Storygame.Tests.Unit/Users/VerifyUserCommandHandlerTests.cs
@@ -1,0 +1,138 @@
+using Moq;
+using Shouldly;
+using Storygame.Cqrs;
+using Storygame.Users;
+using Storygame.Users.Commands;
+using Storygame.Users.Events;
+
+namespace Storygame.Tests.Unit.Users;
+
+[TestFixture]
+public class VerifyUserCommandHandlerTests
+{
+    private Mock<IUsersRepository> _repository = null!;
+    private Mock<IDispatcher> _dispatcher = null!;
+    private VerifyUserCommandHandler _handler = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repository = new Mock<IUsersRepository>();
+        _dispatcher = new Mock<IDispatcher>();
+        _handler = new VerifyUserCommandHandler(_repository.Object, _dispatcher.Object);
+    }
+
+    [Test]
+    public async Task Throws_when_user_is_already_verified()
+    {
+        var user = VerifiedUser();
+        _repository.Setup(r => r.GetUserByEmail(user.Email, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        await Should.ThrowAsync<ArgumentException>(() =>
+            _handler.HandleAsync(new VerifyUserCommand(user.Email, "ANYCODE"), CancellationToken.None));
+    }
+
+    [Test]
+    public async Task Throws_when_verification_code_does_not_match()
+    {
+        var user = UnverifiedUser();
+        _repository.Setup(r => r.GetUserByEmail(user.Email, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+        _repository.Setup(r => r.GetUserVerificationCode(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserVerificationCode(Guid.NewGuid(), user.Id, "CORRECTCODE"));
+
+        await Should.ThrowAsync<ArgumentException>(() =>
+            _handler.HandleAsync(new VerifyUserCommand(user.Email, "WRONGCODE"), CancellationToken.None));
+    }
+
+    [Test]
+    public async Task Sets_verified_at_timestamp_and_updates_user()
+    {
+        var user = UnverifiedUser();
+        _repository.Setup(r => r.GetUserByEmail(user.Email, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+        _repository.Setup(r => r.GetUserVerificationCode(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserVerificationCode(Guid.NewGuid(), user.Id, "VALIDCODE"));
+
+        User? updatedUser = null;
+        _repository.Setup(r => r.UpdateUser(It.IsAny<User>(), It.IsAny<CancellationToken>()))
+            .Callback<User, CancellationToken>((u, _) => updatedUser = u);
+
+        await _handler.HandleAsync(new VerifyUserCommand(user.Email, "VALIDCODE"), CancellationToken.None);
+
+        updatedUser.ShouldNotBeNull();
+        updatedUser.VerifiedAt.ShouldNotBeNull();
+        updatedUser.VerifiedAt!.Value.ShouldBeInRange(DateTime.UtcNow.AddSeconds(-5), DateTime.UtcNow);
+    }
+
+    [Test]
+    public async Task Publishes_event_with_user_id_and_verification_timestamp()
+    {
+        var user = UnverifiedUser();
+        _repository.Setup(r => r.GetUserByEmail(user.Email, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+        _repository.Setup(r => r.GetUserVerificationCode(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserVerificationCode(Guid.NewGuid(), user.Id, "VALIDCODE"));
+
+        UserVerifiedEvent? publishedEvent = null;
+        _dispatcher.Setup(d => d.PublishAsync(It.IsAny<UserVerifiedEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<UserVerifiedEvent, CancellationToken>((e, _) => publishedEvent = e);
+
+        await _handler.HandleAsync(new VerifyUserCommand(user.Email, "VALIDCODE"), CancellationToken.None);
+
+        publishedEvent.ShouldNotBeNull();
+        publishedEvent.UserId.ShouldBe(user.Id);
+        publishedEvent.VerifiedAt.ShouldBeInRange(DateTime.UtcNow.AddSeconds(-5), DateTime.UtcNow);
+    }
+
+    [Test]
+    public async Task Does_not_update_user_when_code_is_wrong()
+    {
+        var user = UnverifiedUser();
+        _repository.Setup(r => r.GetUserByEmail(user.Email, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+        _repository.Setup(r => r.GetUserVerificationCode(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserVerificationCode(Guid.NewGuid(), user.Id, "CORRECTCODE"));
+
+        await Should.ThrowAsync<ArgumentException>(() =>
+            _handler.HandleAsync(new VerifyUserCommand(user.Email, "WRONGCODE"), CancellationToken.None));
+
+        _repository.Verify(r => r.UpdateUser(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Does_not_publish_event_when_code_is_wrong()
+    {
+        var user = UnverifiedUser();
+        _repository.Setup(r => r.GetUserByEmail(user.Email, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+        _repository.Setup(r => r.GetUserVerificationCode(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserVerificationCode(Guid.NewGuid(), user.Id, "CORRECTCODE"));
+
+        await Should.ThrowAsync<ArgumentException>(() =>
+            _handler.HandleAsync(new VerifyUserCommand(user.Email, "WRONGCODE"), CancellationToken.None));
+
+        _dispatcher.Verify(
+            d => d.PublishAsync(It.IsAny<UserVerifiedEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static User UnverifiedUser() => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = "Jan Kowalski",
+        Email = "jan@example.com",
+        RegisteredAt = DateTime.UtcNow.AddDays(-1),
+        VerifiedAt = null
+    };
+
+    private static User VerifiedUser() => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = "Jan Kowalski",
+        Email = "jan@example.com",
+        RegisteredAt = DateTime.UtcNow.AddDays(-1),
+        VerifiedAt = new DateTime(2026, 5, 1)
+    };
+}


### PR DESCRIPTION
- AddBookToLibraryCommandHandler (Library)
- GetLibraryBookByIdQueryHandler (Library)
- GetUserBooksFromLibraryQueryHandler (Library)
- RegisterUserCommandHandler (Users)
- VerifyUserCommandHandler (Users)
- GetUserByEmailQueryHandler (Users)
- GetUserByIdQueryHandler (Users)
- StartTrackingBookCommandHandler (Tracking)
- UpdateTrackingIndexCommandHandler (Tracking)
- GetTrackingStatisticsQueryHandler (Tracking)
- GetUserTrackingsQueryHandler (Tracking)
- SearchCatalogQueryHandler (Catalog)

48 tests total using NUnit, Moq, and Shouldly.
Added Moq 4.20.72 and Shouldly 4.3.0 to test project. Added project references for Users, Tracking, and Catalog modules.