### PR TITLE
Add integration tests for all endpoints

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(Get-ChildItem -Path \"C:\\\\Users\\\\marci\\\\Desktop\\\\Storygame\\\\.claude\\\\worktrees\\\\inspiring-engelbart-b49759\" -Recurse -Filter \"*.csproj\")",
+      "Bash(Select-Object FullName)",
+      "Bash(ConvertTo-Csv -NoTypeInformation)",
+      "Bash(Out-String)",
+      "Bash(dotnet build *)",
+      "Bash(dotnet test *)",
+      "Bash(git fetch *)",
+      "Bash(git merge *)",
+      "Bash(Select-String -Pattern \"\\(Passed|Failed|Error|passed|failed\\)\")",
+      "Bash(Select-Object -Last 30)",
+      "Bash(git add *)"
+    ]
+  }
+}

--- a/src/Storygame.Client/StorygameClient.cs
+++ b/src/Storygame.Client/StorygameClient.cs
@@ -36,8 +36,11 @@ public class StorygameClient
         HttpClient = httpClient;
     }
 
-    public Task Login(LoginRequest request) 
+    public Task Login(LoginRequest request)
         => Post(UsersPath + "/Login", request);
+
+    public Task Logout()
+        => Post(UsersPath + "/Logout");
 
     public Task ConfirmLogin(ConfirmLoginRequest request)
         => Post(UsersPath + "/ConfirmLogin", request);
@@ -54,8 +57,15 @@ public class StorygameClient
     public Task<MeResponse> Me() 
         => Get<MeResponse>(UsersPath + "/Me");
 
-    public Task<GetCatalogResponse> GetCatalog() 
-        => Get<GetCatalogResponse>(CatalogPath);
+    public Task<GetCatalogResponse> GetCatalog(string? titleContains = null, bool? hasTextEdition = null, bool? hasAudiobook = null)
+    {
+        var query = new List<string>();
+        if (titleContains != null) query.Add($"titleContains={Uri.EscapeDataString(titleContains)}");
+        if (hasTextEdition != null) query.Add($"hasTextEdition={hasTextEdition.Value.ToString().ToLower()}");
+        if (hasAudiobook != null) query.Add($"hasAudiobook={hasAudiobook.Value.ToString().ToLower()}");
+        var qs = query.Count > 0 ? "?" + string.Join("&", query) : "";
+        return Get<GetCatalogResponse>(CatalogPath + qs);
+    }
 
     public Task AddToLibrary(AddToLibraryRequest request) 
         => Post(LibraryPath, request);
@@ -69,9 +79,8 @@ public class StorygameClient
     public Task<GetTrackingsResponse> GetTrackings() 
         => Get<GetTrackingsResponse>(TrackingPath);
 
-    //todo test
     public Task<GetStatisticsResponse> GetStatistics(Guid trackingId, DateTime fromDateTime, DateTime toDateTime, TimePeriodDto timePeriod)
-        => Get<GetStatisticsResponse>(TrackingPath + $"/{trackingId}/stats?fromDateTime={fromDateTime}&toDateTime={toDateTime}&timePeriod={timePeriod}");
+        => Get<GetStatisticsResponse>(TrackingPath + $"/{trackingId}/stats?fromDateTime={fromDateTime:O}&toDateTime={toDateTime:O}&timePeriod={timePeriod}");
 
     public Task UpdateIndex(Guid trackingId, UpdateIndexRequest request) 
         => Post(TrackingPath + $"/{trackingId}/index", request);

--- a/src/Tests/Storygame.Tests.Integration/Catalog/CatalogTests.cs
+++ b/src/Tests/Storygame.Tests.Integration/Catalog/CatalogTests.cs
@@ -1,0 +1,50 @@
+using System.Net;
+
+namespace Storygame.Tests.Integration.Catalog;
+
+[TestFixture]
+public class CatalogTests : AuthenticatedIntegrationTestBase
+{
+    [Test]
+    public async Task GetCatalog_ReturnsAllBooks()
+    {
+        var response = await Client.GetCatalog();
+
+        response.Books.ShouldNotBeEmpty();
+    }
+
+    [Test]
+    public async Task GetCatalog_FilterByTitle_ReturnsMatchingBooks()
+    {
+        var response = await Client.GetCatalog(titleContains: "C#");
+
+        response.Books.ShouldNotBeEmpty();
+        response.Books.ShouldAllBe(b => b.Title.Contains("C#"));
+    }
+
+    [Test]
+    public async Task GetCatalog_FilterByAudiobook_ReturnsOnlyAudiobooks()
+    {
+        var response = await Client.GetCatalog(hasAudiobook: true);
+
+        response.Books.ShouldNotBeEmpty();
+        response.Books.ShouldAllBe(b => b.AudiobookFields.Exist);
+    }
+
+    [Test]
+    public async Task GetCatalog_FilterByNoAudiobook_ReturnsOnlyTextEditions()
+    {
+        var response = await Client.GetCatalog(hasAudiobook: false);
+
+        response.Books.ShouldNotBeEmpty();
+        response.Books.ShouldAllBe(b => !b.AudiobookFields.Exist);
+    }
+
+    [Test]
+    public async Task GetCatalog_WhenUnauthenticated_Returns401()
+    {
+        var status = await GetUnauthenticated("/api/catalog");
+
+        status.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+}

--- a/src/Tests/Storygame.Tests.Integration/InMemoryLibraryRepository.cs
+++ b/src/Tests/Storygame.Tests.Integration/InMemoryLibraryRepository.cs
@@ -1,0 +1,27 @@
+using Storygame.Library;
+using System.Collections.Concurrent;
+
+namespace Storygame.Tests.Integration;
+
+internal class InMemoryLibraryRepository : ILibraryRepository
+{
+    private readonly ConcurrentDictionary<Guid, Book> _books = new();
+
+    public Task AddBook(Book book, CancellationToken ct)
+    {
+        _books[book.Id] = book;
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> CheckIfUserAlreadyHasThisBook(Guid userId, Guid catalogBookId, MediaType mediaType, CancellationToken ct)
+    {
+        var exists = _books.Values.Any(b => b.UserId == userId && b.CatalogBookId == catalogBookId && b.MediaType == mediaType);
+        return Task.FromResult(exists);
+    }
+
+    public Task<IEnumerable<Book>> GetUserBooks(Guid userId, CancellationToken ct)
+        => Task.FromResult(_books.Values.Where(b => b.UserId == userId));
+
+    public Task<Book> GetBookById(Guid bookId, Guid userId, CancellationToken ct)
+        => Task.FromResult(_books.Values.Single(b => b.Id == bookId && b.UserId == userId));
+}

--- a/src/Tests/Storygame.Tests.Integration/InMemoryTrackingRepository.cs
+++ b/src/Tests/Storygame.Tests.Integration/InMemoryTrackingRepository.cs
@@ -1,0 +1,64 @@
+using Storygame.Tracking;
+using System.Collections.Concurrent;
+using TrackingEntity = Storygame.Tracking.Tracking;
+
+namespace Storygame.Tests.Integration;
+
+internal class InMemoryTrackingRepository : ITrackingRepository
+{
+    private readonly ConcurrentDictionary<Guid, TrackingEntity> _trackings = new();
+    private readonly ConcurrentDictionary<Guid, TrackingStatistic> _statistics = new();
+
+    public Task AddTracking(TrackingEntity tracking, CancellationToken ct)
+    {
+        _trackings[tracking.Id] = tracking;
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateTracking(TrackingEntity tracking, CancellationToken ct)
+    {
+        _trackings[tracking.Id] = tracking;
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> CheckIfBookIsAlreadyTracked(Guid libraryBookId, CancellationToken ct)
+        => Task.FromResult(_trackings.Values.Any(t => t.LibraryBookId == libraryBookId));
+
+    public Task<IEnumerable<TrackingEntity>> GetUserTrackings(Guid userId, CancellationToken ct)
+        => Task.FromResult(_trackings.Values.Where(t => t.UserId == userId));
+
+    public Task<TrackingEntity> GetTracking(Guid trackingId, CancellationToken ct)
+        => Task.FromResult(_trackings[trackingId]);
+
+    public Task AddStatistic(TrackingStatistic trackingStatistic, CancellationToken ct)
+    {
+        _statistics[trackingStatistic.Id] = trackingStatistic;
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateStatistic(TrackingStatistic trackingStatistic, CancellationToken ct)
+    {
+        _statistics[trackingStatistic.Id] = trackingStatistic;
+        return Task.CompletedTask;
+    }
+
+    public Task<IEnumerable<TrackingStatistic>> GetStatistics(Guid trackingId, TimeRange timeRange, TimePeriod timePeriod, CancellationToken ct)
+    {
+        var stats = _statistics.Values.Where(s =>
+            s.TrackingId == trackingId &&
+            s.TimePeriod == timePeriod &&
+            s.TimeRange.From >= timeRange.From &&
+            s.TimeRange.To <= timeRange.To);
+        return Task.FromResult(stats);
+    }
+
+    public Task<TrackingStatistic?> GetStatisticByTimePoint(Guid trackingId, DateTime timePoint, TimePeriod timePeriod, CancellationToken ct)
+    {
+        var stat = _statistics.Values.FirstOrDefault(s =>
+            s.TrackingId == trackingId &&
+            s.TimePeriod == timePeriod &&
+            s.TimeRange.From <= timePoint &&
+            s.TimeRange.To >= timePoint);
+        return Task.FromResult(stat);
+    }
+}

--- a/src/Tests/Storygame.Tests.Integration/IntegrationTestBase.cs
+++ b/src/Tests/Storygame.Tests.Integration/IntegrationTestBase.cs
@@ -1,0 +1,43 @@
+using Storygame.Client;
+using Storygame.Contracts.WebApi;
+using Storygame.Contracts.WebApi.Requests;
+using System.Net;
+
+namespace Storygame.Tests.Integration;
+
+public abstract class IntegrationTestBase
+{
+    protected StorygameClient Client { get; private set; } = null!;
+
+    [SetUp]
+    public void CreateClient()
+    {
+        Client = WebAppFactory.CreateClientWithDefaultMocks();
+    }
+
+    protected static async Task AuthenticateAs(StorygameClient client, string name, string email)
+    {
+        await client.Register(new RegisterRequest(name, email));
+        var verificationCode = (await client.Mail(email)).Single(m => m.Subject == "Verification code").Message;
+        await client.Verify(new VerifyUserRequest(email, verificationCode));
+        await client.Login(new LoginRequest(email));
+        var confirmationKey = (await client.Mail(email)).Single(m => m.Subject == "Login confirmation").Message;
+        await client.ConfirmLogin(new ConfirmLoginRequest(confirmationKey));
+    }
+
+    protected static async Task<HttpStatusCode> GetUnauthenticated(string path)
+    {
+        var client = WebAppFactory.CreateClientWithDefaultMocks();
+        var response = await client.HttpClient.GetAsync(path);
+        return response.StatusCode;
+    }
+}
+
+public abstract class AuthenticatedIntegrationTestBase : IntegrationTestBase
+{
+    protected const string DefaultName = "Test User";
+    protected const string DefaultEmail = "test@example.com";
+
+    [SetUp]
+    public Task Authenticate() => AuthenticateAs(Client, DefaultName, DefaultEmail);
+}

--- a/src/Tests/Storygame.Tests.Integration/Library/LibraryTests.cs
+++ b/src/Tests/Storygame.Tests.Integration/Library/LibraryTests.cs
@@ -1,0 +1,61 @@
+using Storygame.Contracts.WebApi.Dtos;
+using Storygame.Contracts.WebApi.Requests;
+using System.Net;
+
+namespace Storygame.Tests.Integration.Library;
+
+[TestFixture]
+public class LibraryTests : AuthenticatedIntegrationTestBase
+{
+    [Test]
+    public async Task GetLibrary_Initially_ReturnsEmptyList()
+    {
+        var response = await Client.GetLibrary();
+
+        response.Books.ShouldBeEmpty();
+    }
+
+    [Test]
+    public async Task AddToLibrary_AddsBook_VisibleInGetLibrary()
+    {
+        await Client.AddToLibrary(new AddToLibraryRequest(null, null, "Dune", "Sci-fi epic", MediaTypeDto.Ebook, 412));
+
+        var library = await Client.GetLibrary();
+
+        library.Books.ShouldHaveSingleItem();
+        var book = library.Books[0];
+        book.Title.ShouldBe("Dune");
+        book.Description.ShouldBe("Sci-fi epic");
+        book.MediaType.ShouldBe(MediaTypeDto.Ebook);
+        book.Length.ShouldBe(412);
+    }
+
+    [Test]
+    public async Task AddToLibrary_MultipleBooksWithNoCatalogId_AllAdded()
+    {
+        await Client.AddToLibrary(new AddToLibraryRequest(null, null, "Book A", "Desc A", MediaTypeDto.Ebook, 100));
+        await Client.AddToLibrary(new AddToLibraryRequest(null, null, "Book B", "Desc B", MediaTypeDto.Audiobook, 200));
+
+        var library = await Client.GetLibrary();
+
+        library.Books.Length.ShouldBe(2);
+    }
+
+    [Test]
+    public async Task AddToLibrary_DuplicateCatalogBook_Fails()
+    {
+        var catalogBookId = Guid.NewGuid();
+        await Client.AddToLibrary(new AddToLibraryRequest(catalogBookId, null, "Dune", "Sci-fi epic", MediaTypeDto.Ebook, 412));
+
+        await Should.ThrowAsync<HttpRequestException>(() =>
+            Client.AddToLibrary(new AddToLibraryRequest(catalogBookId, null, "Dune", "Sci-fi epic", MediaTypeDto.Ebook, 412)));
+    }
+
+    [Test]
+    public async Task GetLibrary_WhenUnauthenticated_Returns401()
+    {
+        var status = await GetUnauthenticated("/api/library/");
+
+        status.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+}

--- a/src/Tests/Storygame.Tests.Integration/Storygame.Tests.Integration.csproj
+++ b/src/Tests/Storygame.Tests.Integration/Storygame.Tests.Integration.csproj
@@ -22,11 +22,14 @@
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="SharpCompress" Version="0.48.0" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Snappier" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Contracts\Storygame.Contracts.WebApi\Storygame.Contracts.WebApi.csproj" />
+    <ProjectReference Include="..\..\Domain\Storygame.Library\Storygame.Library.csproj" />
+    <ProjectReference Include="..\..\Domain\Storygame.Tracking\Storygame.Tracking.csproj" />
     <ProjectReference Include="..\..\Domain\Storygame.Users\Storygame.Users.csproj" />
     <ProjectReference Include="..\..\Storygame.Client\Storygame.Client.csproj" />
     <ProjectReference Include="..\..\Storygame.Web\Storygame.Web.csproj" />
@@ -34,6 +37,7 @@
 
   <ItemGroup>
     <Using Include="NUnit.Framework" />
+    <Using Include="Shouldly" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Storygame.Tests.Integration/Tracking/TrackingTests.cs
+++ b/src/Tests/Storygame.Tests.Integration/Tracking/TrackingTests.cs
@@ -1,0 +1,114 @@
+using Storygame.Contracts.WebApi.Dtos;
+using Storygame.Contracts.WebApi.Requests;
+using Storygame.Contracts.WebApi.Responses;
+using System.Net;
+
+namespace Storygame.Tests.Integration.Tracking;
+
+[TestFixture]
+public class TrackingTests : AuthenticatedIntegrationTestBase
+{
+    [Test]
+    public async Task GetTrackings_Initially_ReturnsEmptyList()
+    {
+        var response = await Client.GetTrackings();
+
+        response.Trackings.ShouldBeEmpty();
+    }
+
+    [Test]
+    public async Task StartTracking_CreatesTracking()
+    {
+        var libraryBookId = await AddBookToLibraryAndGetId();
+
+        await Client.StartTracking(new StartTrackingRequest(libraryBookId));
+        var trackings = await Client.GetTrackings();
+
+        trackings.Trackings.ShouldHaveSingleItem();
+        var tracking = trackings.Trackings[0];
+        tracking.LibraryBookId.ShouldBe(libraryBookId);
+        tracking.CurrentIndex.ShouldBe(0);
+        tracking.IsStarted.ShouldBeFalse();
+        tracking.IsFinished.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task StartTracking_SameBookTwice_Fails()
+    {
+        var libraryBookId = await AddBookToLibraryAndGetId();
+        await Client.StartTracking(new StartTrackingRequest(libraryBookId));
+
+        await Should.ThrowAsync<HttpRequestException>(() =>
+            Client.StartTracking(new StartTrackingRequest(libraryBookId)));
+    }
+
+    [Test]
+    public async Task UpdateIndex_UpdatesCurrentIndex()
+    {
+        var libraryBookId = await AddBookToLibraryAndGetId();
+        await Client.StartTracking(new StartTrackingRequest(libraryBookId));
+        var trackingId = (await Client.GetTrackings()).Trackings[0].Id;
+
+        await Client.UpdateIndex(trackingId, new UpdateIndexRequest(50));
+        var trackings = await Client.GetTrackings();
+
+        trackings.Trackings[0].CurrentIndex.ShouldBe(50);
+        trackings.Trackings[0].IsStarted.ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task UpdateIndex_ToTotalLength_MarksAsFinished()
+    {
+        var libraryBookId = await AddBookToLibraryAndGetId(length: 100);
+        await Client.StartTracking(new StartTrackingRequest(libraryBookId));
+        var trackingId = (await Client.GetTrackings()).Trackings[0].Id;
+
+        await Client.UpdateIndex(trackingId, new UpdateIndexRequest(100));
+        var trackings = await Client.GetTrackings();
+
+        trackings.Trackings[0].IsFinished.ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task GetStatistics_ReturnsEmptyBeforeAnyIndexUpdate()
+    {
+        var libraryBookId = await AddBookToLibraryAndGetId();
+        await Client.StartTracking(new StartTrackingRequest(libraryBookId));
+        var trackingId = (await Client.GetTrackings()).Trackings[0].Id;
+
+        var stats = await Client.GetStatistics(trackingId, DateTime.UtcNow.AddDays(-7), DateTime.UtcNow, TimePeriodDto.Day);
+
+        stats.TrackingStatistics.ShouldBeEmpty();
+    }
+
+    [Test]
+    public async Task GetStatistics_AfterIndexUpdate_ReturnsStatistics()
+    {
+        var libraryBookId = await AddBookToLibraryAndGetId();
+        await Client.StartTracking(new StartTrackingRequest(libraryBookId));
+        var trackingId = (await Client.GetTrackings()).Trackings[0].Id;
+
+        await Client.UpdateIndex(trackingId, new UpdateIndexRequest(30));
+        await Task.Delay(1500);
+
+        var stats = await Client.GetStatistics(trackingId, DateTime.UtcNow.AddDays(-1), DateTime.UtcNow.AddDays(1), TimePeriodDto.Day);
+
+        stats.TrackingStatistics.ShouldNotBeEmpty();
+        stats.TrackingStatistics[0].Value.ShouldBe(30);
+        stats.TrackingStatistics[0].TimePeriod.ShouldBe(TimePeriodDto.Day);
+    }
+
+    [Test]
+    public async Task GetTrackings_WhenUnauthenticated_Returns401()
+    {
+        var status = await GetUnauthenticated("/api/tracking/");
+
+        status.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    private async Task<Guid> AddBookToLibraryAndGetId(int length = 300)
+    {
+        await Client.AddToLibrary(new AddToLibraryRequest(null, null, "Test Book", "A test book", MediaTypeDto.Ebook, length));
+        return (await Client.GetLibrary()).Books[0].Id;
+    }
+}

--- a/src/Tests/Storygame.Tests.Integration/Users/UsersTests.cs
+++ b/src/Tests/Storygame.Tests.Integration/Users/UsersTests.cs
@@ -1,14 +1,90 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Storygame.Client;
-using Storygame.Users;
-using System;
-using System.Collections.Generic;
-using System.Text;
+using Storygame.Contracts.WebApi;
+using Storygame.Contracts.WebApi.Requests;
+using System.Net;
 
 namespace Storygame.Tests.Integration.Users;
 
-//todo add tests
 [TestFixture]
-public class UsersTests
+public class UsersTests : IntegrationTestBase
 {
+    [Test]
+    public async Task GetCSRF_ReturnsToken()
+    {
+        var response = await Client.HttpClient.GetAsync("/api/users/CSRF");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var token = await response.Content.ReadAsStringAsync();
+        token.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public async Task Register_SendsVerificationEmail()
+    {
+        await Client.Register(new RegisterRequest("Alice", "alice@example.com"));
+
+        var mail = await Client.Mail("alice@example.com");
+        mail.ShouldHaveSingleItem();
+        mail[0].Message.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public async Task Register_WithDuplicateEmail_Fails()
+    {
+        await Client.Register(new RegisterRequest("Alice", "alice@example.com"));
+
+        await Should.ThrowAsync<HttpRequestException>(() =>
+            Client.Register(new RegisterRequest("Alice2", "alice@example.com")));
+    }
+
+    [Test]
+    public async Task Verify_WithValidCode_Succeeds()
+    {
+        await Client.Register(new RegisterRequest("Bob", "bob@example.com"));
+        var verificationCode = (await Client.Mail("bob@example.com")).Single(m => m.Subject == "Verification code").Message;
+
+        await Should.NotThrowAsync(() =>
+            Client.Verify(new VerifyUserRequest("bob@example.com", verificationCode)));
+    }
+
+    [Test]
+    public async Task Login_SendsConfirmationEmail()
+    {
+        await Client.Register(new RegisterRequest("Carol", "carol@example.com"));
+        var verificationCode = (await Client.Mail("carol@example.com")).Single(m => m.Subject == "Verification code").Message;
+        await Client.Verify(new VerifyUserRequest("carol@example.com", verificationCode));
+
+        await Client.Login(new LoginRequest("carol@example.com"));
+
+        var allMail = await Client.Mail("carol@example.com");
+        allMail.Length.ShouldBe(2);
+    }
+
+    [Test]
+    public async Task ConfirmLogin_AuthenticatesUser()
+    {
+        await AuthenticateAs(Client, "Dave", "dave@example.com");
+
+        var me = await Client.Me();
+
+        me.Name.ShouldBe("Dave");
+    }
+
+    [Test]
+    public async Task GetMe_WhenUnauthenticated_Returns401()
+    {
+        var response = await Client.HttpClient.GetAsync("/api/users/Me");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Logout_DeauthenticatesUser()
+    {
+        await AuthenticateAs(Client, "Eve", "eve@example.com");
+
+        await Client.Logout();
+
+        var response = await Client.HttpClient.GetAsync("/api/users/Me");
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
 }

--- a/src/Tests/Storygame.Tests.Integration/WebAppFactory.cs
+++ b/src/Tests/Storygame.Tests.Integration/WebAppFactory.cs
@@ -2,7 +2,9 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Storygame.Client;
+using Storygame.Library;
 using Storygame.Storage;
+using Storygame.Tracking;
 using Storygame.Users;
 
 namespace Storygame.Tests.Integration;
@@ -43,6 +45,8 @@ public static class WebAppFactory
             {
                 services.Replace(ServiceDescriptor.Singleton<IUsersRepository, InMemoryUsersRepository>());
                 services.Replace(ServiceDescriptor.Singleton<IEventsRepository, InMemoryEventsRepository>());
+                services.Replace(ServiceDescriptor.Singleton<ILibraryRepository, InMemoryLibraryRepository>());
+                services.Replace(ServiceDescriptor.Singleton<ITrackingRepository, InMemoryTrackingRepository>());
             }
         });
     }


### PR DESCRIPTION
- InMemoryLibraryRepository, InMemoryTrackingRepository — brakujące implementacje do testów (wcześniej były tylko Users i Events)
- IntegrationTestBase / AuthenticatedIntegrationTestBase — wspólna infrastruktura: tworzenie klienta per test, helper AuthenticateAs z poprawną obsługą kolejności maili (ConcurrentBag jest LIFO), GetUnauthenticated zastępujący zduplikowany wzorzec
- UsersTests, CatalogTests, LibraryTests, TrackingTests — 29 testów integracyjnych pokrywających wszystkie endpointy
- StorygameClient: dodano Logout(), filtry do GetCatalog(), poprawiony format daty w GetStatistics() na ISO 8601